### PR TITLE
Fix subscriber badges

### DIFF
--- a/chatdownloader/src/twitch_utils.rs
+++ b/chatdownloader/src/twitch_utils.rs
@@ -63,7 +63,7 @@ impl TwitchAPIWrapper {
         let response = self.twitch.req_get(request, &self.token);
         let global_badges = response.await.unwrap().data;
 
-        let all_badges = [channel_badges, global_badges].concat();
+        let all_badges = [global_badges, channel_badges].concat();
 
         let mut badge_sets: HashMap<String, HashMap<String, BadgeInformation>> = HashMap::new();
 


### PR DESCRIPTION
Currently, channel subscriber badges are being applied before global subscriber badges, resulting in a channel's subscriber badges being ignored.