### PR TITLE
Refactor out chat messages to an enum

### DIFF
--- a/rust/elo/src/_types/clptypes.rs
+++ b/rust/elo/src/_types/clptypes.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use twitch_utils::twitchtypes::Comment;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct UserChatPerformance {
@@ -56,4 +57,36 @@ pub struct MetricUpdate {
 pub struct MetadataUpdate {
     pub metadata_name: String,
     pub updates: HashMap<String, MetadataTypes>,
+}
+
+impl MetricUpdate {
+    pub fn empty_with_name(name: String) -> Self {
+        Self {
+            metric_name: name,
+            updates: HashMap::new(),
+        }
+    }
+}
+
+impl MetadataUpdate {
+    pub fn empty_with_name(name: String) -> Self {
+        Self {
+            metadata_name: name,
+            updates: HashMap::new(),
+        }
+    }
+}
+
+/// Message enum representing all possible messages that go through
+/// chat log processor.
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// Represents a Twitch message
+    TWITCH(Comment),
+}
+
+impl From<Comment> for Message {
+    fn from(value: Comment) -> Self {
+        Self::TWITCH(value)
+    }
 }

--- a/rust/elo/src/_types/clptypes.rs
+++ b/rust/elo/src/_types/clptypes.rs
@@ -82,11 +82,11 @@ impl MetadataUpdate {
 #[derive(Debug, Clone)]
 pub enum Message {
     /// Represents a Twitch message
-    TWITCH(Comment),
+    Twitch(Comment),
 }
 
 impl From<Comment> for Message {
     fn from(value: Comment) -> Self {
-        Self::TWITCH(value)
+        Self::Twitch(value)
     }
 }

--- a/rust/elo/src/lib.rs
+++ b/rust/elo/src/lib.rs
@@ -1,11 +1,10 @@
 use std::{collections::HashMap, sync::atomic::AtomicU32};
 
-use _types::clptypes::{MetadataTypes, MetadataUpdate, MetricUpdate, UserChatPerformance};
+use _types::clptypes::{Message, MetadataTypes, MetadataUpdate, MetricUpdate, UserChatPerformance};
 use log::{debug, warn};
 use metadata::setup_metadata_and_channels;
 use metrics::setup_metrics_and_channels;
 use tokio::sync::mpsc;
-use twitch_utils::twitchtypes::Comment;
 
 pub mod _constants;
 pub mod _types;
@@ -15,9 +14,9 @@ pub mod metrics;
 
 pub struct MessageProcessor {
     metric_processor_task: tokio::task::JoinHandle<()>,
-    metric_sender: tokio::sync::broadcast::Sender<(Comment, u32)>,
+    metric_sender: tokio::sync::broadcast::Sender<(Message, u32)>,
     metadata_processor_task: tokio::task::JoinHandle<()>,
-    metadata_sender: tokio::sync::broadcast::Sender<(Comment, u32)>,
+    metadata_sender: tokio::sync::broadcast::Sender<(Message, u32)>,
     sequence_number: AtomicU32,
     performances_task: tokio::task::JoinHandle<HashMap<String, UserChatPerformance>>,
 }
@@ -49,7 +48,7 @@ impl MessageProcessor {
         }
     }
 
-    pub async fn process_message(&self, message: Comment) {
+    pub async fn process_message(&self, message: Message) {
         let sequence_number = self
             .sequence_number
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/rust/elo/src/metadata/badges.rs
+++ b/rust/elo/src/metadata/badges.rs
@@ -1,6 +1,4 @@
-/*
-Assigns badges to each user
-*/
+//! Assigns badges to each user
 use log::error;
 use std::collections::HashMap;
 use twitch_utils::twitchtypes::Comment;
@@ -95,7 +93,7 @@ impl AbstractMetadata for Badges {
 
     fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
         match message {
-            Message::TWITCH(comment) => self.get_metadata_twitch(comment),
+            Message::Twitch(comment) => self.get_metadata_twitch(comment),
         }
     }
 }

--- a/rust/elo/src/metadata/badges.rs
+++ b/rust/elo/src/metadata/badges.rs
@@ -3,15 +3,58 @@ Assigns badges to each user
 */
 use log::error;
 use std::collections::HashMap;
+use twitch_utils::twitchtypes::Comment;
 
 use crate::_constants::VED_CH_ID;
-use crate::_types::clptypes::{BadgeInformation, MetadataTypes, MetadataUpdate};
+use crate::_types::clptypes::{BadgeInformation, Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
-use twitch_utils::twitchtypes::Comment;
 use twitch_utils::TwitchAPIWrapper;
 
 pub struct Badges {
     badges: HashMap<String, HashMap<String, BadgeInformation>>,
+}
+
+impl Badges {
+    fn get_metadata_twitch(&self, comment: Comment) -> MetadataUpdate {
+        let mut metadata: Vec<BadgeInformation> = vec![];
+        let user_badges = if let Some(user_badges) = comment.message.user_badges {
+            user_badges
+        } else {
+            let mut out: HashMap<String, MetadataTypes> = HashMap::new();
+            out.insert(
+                comment.commenter._id.clone(),
+                MetadataTypes::BadgeList(vec![]),
+            );
+            return MetadataUpdate {
+                metadata_name: self.get_name(),
+                updates: out,
+            };
+        };
+        for badge in user_badges {
+            let badge_set = self.badges.get(&badge._id);
+            if badge_set.is_none() {
+                error!("Badge set not found for badge id {}", badge._id);
+                continue;
+            }
+            let badge_set = badge_set.unwrap();
+            let badge_info = badge_set.get(&badge.version);
+            if badge_info.is_none() {
+                error!(
+                    "Badge info not found for badge id {} and version {}",
+                    badge._id, badge.version
+                );
+                continue;
+            }
+            metadata.push(badge_info.unwrap().clone());
+        }
+        MetadataUpdate {
+            metadata_name: self.get_name(),
+            updates: HashMap::from([(
+                comment.commenter._id.clone(),
+                MetadataTypes::BadgeList(metadata),
+            )]),
+        }
+    }
 }
 
 impl AbstractMetadata for Badges {
@@ -50,44 +93,9 @@ impl AbstractMetadata for Badges {
         MetadataTypes::BadgeList(vec![])
     }
 
-    fn get_metadata(&self, comment: Comment, _sequence_no: u32) -> MetadataUpdate {
-        let mut metadata: Vec<BadgeInformation> = vec![];
-        let user_badges = if let Some(user_badges) = comment.message.user_badges {
-            user_badges
-        } else {
-            let mut out: HashMap<String, MetadataTypes> = HashMap::new();
-            out.insert(
-                comment.commenter._id.clone(),
-                MetadataTypes::BadgeList(vec![]),
-            );
-            return MetadataUpdate {
-                metadata_name: self.get_name(),
-                updates: out,
-            };
-        };
-        for badge in user_badges {
-            let badge_set = self.badges.get(&badge._id);
-            if badge_set.is_none() {
-                error!("Badge set not found for badge id {}", badge._id);
-                continue;
-            }
-            let badge_set = badge_set.unwrap();
-            let badge_info = badge_set.get(&badge.version);
-            if badge_info.is_none() {
-                error!(
-                    "Badge info not found for badge id {} and version {}",
-                    badge._id, badge.version
-                );
-                continue;
-            }
-            metadata.push(badge_info.unwrap().clone());
-        }
-        MetadataUpdate {
-            metadata_name: self.get_name(),
-            updates: HashMap::from([(
-                comment.commenter._id.clone(),
-                MetadataTypes::BadgeList(metadata),
-            )]),
+    fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
+        match message {
+            Message::TWITCH(comment) => self.get_metadata_twitch(comment),
         }
     }
 }

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -1,4 +1,4 @@
-///!Get the username and avatar of the user
+//! Get the username and avatar of the user
 use std::collections::HashMap;
 
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
@@ -24,7 +24,7 @@ impl AbstractMetadata for BasicInfo {
 
     fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
         match message {
-            Message::TWITCH(comment) => MetadataUpdate {
+            Message::Twitch(comment) => MetadataUpdate {
                 metadata_name: self.get_name(),
                 updates: HashMap::from([(
                     comment.commenter._id.clone(),

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -1,22 +1,15 @@
-/*
-Get the username and avatar of the user
-*/
-
+///!Get the username and avatar of the user
 use std::collections::HashMap;
 
-use crate::_types::clptypes::{MetadataTypes, MetadataUpdate};
+use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
-use twitch_utils::twitchtypes::Comment;
 use twitch_utils::TwitchAPIWrapper;
 
+/// Figures out if the user is a special role
 #[derive(Default, Debug)]
 pub struct BasicInfo;
 
 impl AbstractMetadata for BasicInfo {
-    /*
-    Figures out if the user is a special role
-    */
-
     async fn new(_twitch: &TwitchAPIWrapper) -> Self {
         Self
     }
@@ -29,18 +22,18 @@ impl AbstractMetadata for BasicInfo {
         MetadataTypes::BasicInfo("".to_string(), "".to_string())
     }
 
-    fn get_metadata(&self, comment: Comment, _sequence_no: u32) -> MetadataUpdate {
-        let mut metadata: HashMap<String, MetadataTypes> = HashMap::new();
-        metadata.insert(
-            comment.commenter._id.clone(),
-            MetadataTypes::BasicInfo(
-                comment.commenter.display_name.clone(),
-                comment.commenter.logo.clone(),
-            ),
-        );
-        MetadataUpdate {
-            metadata_name: self.get_name(),
-            updates: metadata,
+    fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
+        match message {
+            Message::TWITCH(comment) => MetadataUpdate {
+                metadata_name: self.get_name(),
+                updates: HashMap::from([(
+                    comment.commenter._id.clone(),
+                    MetadataTypes::BasicInfo(
+                        comment.commenter.display_name.clone(),
+                        comment.commenter.logo.clone(),
+                    ),
+                )]),
+            },
         }
     }
 }

--- a/rust/elo/src/metadata/metadatatrait.rs
+++ b/rust/elo/src/metadata/metadatatrait.rs
@@ -1,4 +1,4 @@
-///!Represents an abstract metadata
+//! Represents an abstract metadata
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use twitch_utils::TwitchAPIWrapper;
 

--- a/rust/elo/src/metadata/metadatatrait.rs
+++ b/rust/elo/src/metadata/metadatatrait.rs
@@ -1,9 +1,5 @@
-/*
-Represents an abstract metadata
-*/
-
-use crate::_types::clptypes::{MetadataTypes, MetadataUpdate};
-use twitch_utils::twitchtypes::Comment;
+///!Represents an abstract metadata
+use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use twitch_utils::TwitchAPIWrapper;
 
 pub trait AbstractMetadata: Sized {
@@ -14,31 +10,17 @@ pub trait AbstractMetadata: Sized {
     if it needs to make API calls
     */
 
+    /// Creates a new metadata object
     async fn new(twitch: &TwitchAPIWrapper) -> Self
     where
         Self: Sized + Send;
-    /*
-    Create a new metadata object
 
-    :param twitch: A TwitchAPIWrapper object
-    */
-
+    /// Name of this piece of metadata
     fn get_name(&self) -> String;
-    /*
-    Name of this piece of metadata
-    */
 
+    /// Get the defautl value for this metadata
     fn get_default_value(&self) -> MetadataTypes;
-    /*
-    Get the default value for this metadata
-    */
 
-    fn get_metadata(&self, comment: Comment, sequence_no: u32) -> MetadataUpdate;
-    /*
-    Get information about a user from a chat message
-
-    :param: comment A comment from the user
-    :returns: A partial update to a user's metadata (dictionary of
-              username to value)
-    */
+    /// Get information about a user from a chat message
+    fn get_metadata(&self, message: Message, sequence_no: u32) -> MetadataUpdate;
 }

--- a/rust/elo/src/metadata/special_role.rs
+++ b/rust/elo/src/metadata/special_role.rs
@@ -1,7 +1,3 @@
-/*
-Figures out if the user is a special role
-*/
-
 use std::collections::HashMap;
 
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
@@ -11,7 +7,7 @@ use twitch_utils::TwitchAPIWrapper;
 
 const SPECIAL_ROLES: [&str; 3] = ["moderator", "vip", "broadcaster"];
 
-///! Figures out if the user is a special role
+/// Figures out if the user is a special role
 #[derive(Default, Debug)]
 pub struct SpecialRole;
 
@@ -59,7 +55,7 @@ impl AbstractMetadata for SpecialRole {
 
     fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
         match message {
-            Message::TWITCH(comment) => self.get_metadata_twitch(comment),
+            Message::Twitch(comment) => self.get_metadata_twitch(comment),
         }
     }
 }

--- a/rust/elo/src/metadata/special_role.rs
+++ b/rust/elo/src/metadata/special_role.rs
@@ -4,34 +4,19 @@ Figures out if the user is a special role
 
 use std::collections::HashMap;
 
-use crate::_types::clptypes::{MetadataTypes, MetadataUpdate};
+use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
 use twitch_utils::twitchtypes::Comment;
 use twitch_utils::TwitchAPIWrapper;
 
 const SPECIAL_ROLES: [&str; 3] = ["moderator", "vip", "broadcaster"];
 
+///! Figures out if the user is a special role
 #[derive(Default, Debug)]
 pub struct SpecialRole;
 
-impl AbstractMetadata for SpecialRole {
-    /*
-    Figures out if the user is a special role
-    */
-
-    async fn new(_twitch: &TwitchAPIWrapper) -> Self {
-        Self
-    }
-
-    fn get_name(&self) -> String {
-        "special_role".to_string()
-    }
-
-    fn get_default_value(&self) -> MetadataTypes {
-        MetadataTypes::Bool(false)
-    }
-
-    fn get_metadata(&self, comment: Comment, _sequence_no: u32) -> MetadataUpdate {
+impl SpecialRole {
+    fn get_metadata_twitch(&self, comment: Comment) -> MetadataUpdate {
         let mut metadata: HashMap<String, MetadataTypes> = HashMap::new();
         let user_badges = comment.message.user_badges;
         if user_badges.is_none() {
@@ -55,6 +40,26 @@ impl AbstractMetadata for SpecialRole {
         MetadataUpdate {
             metadata_name: self.get_name(),
             updates: metadata,
+        }
+    }
+}
+
+impl AbstractMetadata for SpecialRole {
+    async fn new(_twitch: &TwitchAPIWrapper) -> Self {
+        Self
+    }
+
+    fn get_name(&self) -> String {
+        "special_role".to_string()
+    }
+
+    fn get_default_value(&self) -> MetadataTypes {
+        MetadataTypes::Bool(false)
+    }
+
+    fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
+        match message {
+            Message::TWITCH(comment) => self.get_metadata_twitch(comment),
         }
     }
 }

--- a/rust/elo/src/metrics/bits.rs
+++ b/rust/elo/src/metrics/bits.rs
@@ -1,6 +1,5 @@
-use crate::_types::clptypes::MetricUpdate;
+use crate::_types::clptypes::{Message, MetricUpdate};
 use crate::metrics::metrictrait::AbstractMetric;
-use twitch_utils::twitchtypes::Comment;
 
 const WEIGHT_BITS: f32 = 0.1;
 
@@ -20,8 +19,12 @@ impl AbstractMetric for Bits {
         String::from("bits")
     }
 
-    fn get_metric(&mut self, comment: Comment, _sequence_no: u32) -> MetricUpdate {
-        let score = comment.message.bits_spent as f32 * WEIGHT_BITS;
-        self._shortcut_for_this_comment_user(comment, score)
+    fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
+        match message {
+            Message::TWITCH(comment) => {
+                let score = comment.message.bits_spent as f32 * WEIGHT_BITS;
+                self._shortcut_for_this_comment_user(comment, score)
+            }
+        }
     }
 }

--- a/rust/elo/src/metrics/bits.rs
+++ b/rust/elo/src/metrics/bits.rs
@@ -21,7 +21,7 @@ impl AbstractMetric for Bits {
 
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         match message {
-            Message::TWITCH(comment) => {
+            Message::Twitch(comment) => {
                 let score = comment.message.bits_spent as f32 * WEIGHT_BITS;
                 self._shortcut_for_this_comment_user(comment, score)
             }

--- a/rust/elo/src/metrics/copypastaleader.rs
+++ b/rust/elo/src/metrics/copypastaleader.rs
@@ -124,7 +124,7 @@ impl AbstractMetric for CopypastaLeader {
 
     fn get_metric(&mut self, message: Message, sequence_no: u32) -> MetricUpdate {
         match message {
-            Message::TWITCH(comment) => self.get_metric_for_twitch_message(comment, sequence_no),
+            Message::Twitch(comment) => self.get_metric_for_twitch_message(comment, sequence_no),
         }
     }
 

--- a/rust/elo/src/metrics/copypastaleader.rs
+++ b/rust/elo/src/metrics/copypastaleader.rs
@@ -1,6 +1,6 @@
 use log::debug;
 
-use crate::_types::clptypes::MetricUpdate;
+use crate::_types::clptypes::{Message, MetricUpdate};
 use crate::metrics::metrictrait::AbstractMetric;
 use twitch_utils::twitchtypes::Comment;
 
@@ -13,22 +13,12 @@ pub struct CopypastaLeader {
     history: Vec<(u32, String, String, u32)>,
 }
 
-impl AbstractMetric for CopypastaLeader {
-    async fn new() -> Self {
-        Self {
-            history: Vec::new(),
-        }
-    }
-
-    fn can_parallelize(&self) -> bool {
-        false
-    }
-
-    fn get_name(&self) -> String {
-        String::from("copypasta")
-    }
-
-    fn get_metric(&mut self, comment: Comment, sequence_no: u32) -> MetricUpdate {
+impl CopypastaLeader {
+    fn get_metric_for_twitch_message(
+        &mut self,
+        comment: Comment,
+        sequence_no: u32,
+    ) -> MetricUpdate {
         let text = comment
             .message
             .fragments
@@ -113,6 +103,28 @@ impl AbstractMetric for CopypastaLeader {
         MetricUpdate {
             metric_name: self.get_name(),
             updates: result,
+        }
+    }
+}
+
+impl AbstractMetric for CopypastaLeader {
+    async fn new() -> Self {
+        Self {
+            history: Vec::new(),
+        }
+    }
+
+    fn can_parallelize(&self) -> bool {
+        false
+    }
+
+    fn get_name(&self) -> String {
+        String::from("copypasta")
+    }
+
+    fn get_metric(&mut self, message: Message, sequence_no: u32) -> MetricUpdate {
+        match message {
+            Message::TWITCH(comment) => self.get_metric_for_twitch_message(comment, sequence_no),
         }
     }
 

--- a/rust/elo/src/metrics/emote.rs
+++ b/rust/elo/src/metrics/emote.rs
@@ -1,16 +1,13 @@
-/*
-The emote metric
-*/
-
+///! The emote metric
 use std::collections::HashSet;
 
 use lazy_static::lazy_static;
 use log::{debug, info};
 use serde::Deserialize;
 
-use crate::_constants::VED_CH_ID;
 use crate::_types::clptypes::MetricUpdate;
-use twitch_utils::twitchtypes::{ChatMessageFragment, Comment};
+use crate::{_constants::VED_CH_ID, _types::clptypes::Message};
+use twitch_utils::twitchtypes::ChatMessageFragment;
 
 use super::metrictrait::AbstractMetric;
 
@@ -96,17 +93,21 @@ impl AbstractMetric for Emote {
         String::from("emote")
     }
 
-    fn get_metric(&mut self, comment: Comment, _sequence_no: u32) -> MetricUpdate {
-        let score: f32 = comment
-            .message
-            .fragments
-            .iter()
-            .map(|fragment| {
-                (fragment.emoticon.is_some() as u16 as f32
-                    + self.count_7tv_emotes_in_fragment(fragment) as f32)
-                    * WEIGHT_EMOTES
-            })
-            .sum();
-        self._shortcut_for_this_comment_user(comment, score)
+    fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
+        match message {
+            Message::TWITCH(comment) => {
+                let score: f32 = comment
+                    .message
+                    .fragments
+                    .iter()
+                    .map(|fragment| {
+                        (fragment.emoticon.is_some() as u16 as f32
+                            + self.count_7tv_emotes_in_fragment(fragment) as f32)
+                            * WEIGHT_EMOTES
+                    })
+                    .sum();
+                self._shortcut_for_this_comment_user(comment, score)
+            },
+        }
     }
 }

--- a/rust/elo/src/metrics/emote.rs
+++ b/rust/elo/src/metrics/emote.rs
@@ -1,4 +1,4 @@
-///! The emote metric
+//! The emote metric
 use std::collections::HashSet;
 
 use lazy_static::lazy_static;
@@ -95,7 +95,7 @@ impl AbstractMetric for Emote {
 
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         match message {
-            Message::TWITCH(comment) => {
+            Message::Twitch(comment) => {
                 let score: f32 = comment
                     .message
                     .fragments

--- a/rust/elo/src/metrics/subs.rs
+++ b/rust/elo/src/metrics/subs.rs
@@ -4,9 +4,9 @@ The subs metric
 use lazy_static::lazy_static;
 use regex::Regex;
 
-use crate::_types::clptypes::MetricUpdate;
+use crate::_types::clptypes::{Message, MetricUpdate};
 use crate::metrics::metrictrait::AbstractMetric;
-use twitch_utils::twitchtypes::{ChatMessageFragment, Comment};
+use twitch_utils::twitchtypes::ChatMessageFragment;
 
 const WEIGHT_SUBS: f32 = 0.1;
 
@@ -35,16 +35,20 @@ impl AbstractMetric for Subs {
         String::from("subs")
     }
 
-    fn get_metric(&mut self, comment: Comment, _sequence_no: u32) -> MetricUpdate {
-        let total_subs: i32 = comment
-            .message
-            .fragments
-            .iter()
-            .map(no_of_gifted_subs)
-            .sum();
+    fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
+        match message {
+            Message::TWITCH(comment) => {
+                let total_subs: i32 = comment
+                    .message
+                    .fragments
+                    .iter()
+                    .map(no_of_gifted_subs)
+                    .sum();
 
-        let score = total_subs as f32 * WEIGHT_SUBS;
-        self._shortcut_for_this_comment_user(comment, score)
+                let score = total_subs as f32 * WEIGHT_SUBS;
+                self._shortcut_for_this_comment_user(comment, score)
+            }
+        }
     }
 }
 

--- a/rust/elo/src/metrics/subs.rs
+++ b/rust/elo/src/metrics/subs.rs
@@ -1,6 +1,4 @@
-/*
-The subs metric
-*/
+//! The subs metric
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -37,7 +35,7 @@ impl AbstractMetric for Subs {
 
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         match message {
-            Message::TWITCH(comment) => {
+            Message::Twitch(comment) => {
                 let total_subs: i32 = comment
                     .message
                     .fragments

--- a/rust/elo/src/metrics/text.rs
+++ b/rust/elo/src/metrics/text.rs
@@ -1,7 +1,5 @@
+//! The text metric
 use crate::_types::clptypes::{Message, MetricUpdate};
-/*
-The text metric
-*/
 use crate::metrics::metrictrait::AbstractMetric;
 
 const WEIGHT_TEXT: f32 = 0.02;
@@ -24,7 +22,7 @@ impl AbstractMetric for Text {
 
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         match message {
-            Message::TWITCH(comment) => {
+            Message::Twitch(comment) => {
                 let score = f32::max(0.0, calculate_score(comment.message.body.len()));
                 self._shortcut_for_this_comment_user(comment, score)
             },

--- a/rust/elo/src/metrics/text.rs
+++ b/rust/elo/src/metrics/text.rs
@@ -1,9 +1,8 @@
-use crate::_types::clptypes::MetricUpdate;
+use crate::_types::clptypes::{Message, MetricUpdate};
 /*
 The text metric
 */
 use crate::metrics::metrictrait::AbstractMetric;
-use twitch_utils::twitchtypes::Comment;
 
 const WEIGHT_TEXT: f32 = 0.02;
 
@@ -23,9 +22,13 @@ impl AbstractMetric for Text {
         String::from("text")
     }
 
-    fn get_metric(&mut self, comment: Comment, _sequence_no: u32) -> MetricUpdate {
-        let score = f32::max(0.0, calculate_score(comment.message.body.len()));
-        self._shortcut_for_this_comment_user(comment, score)
+    fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
+        match message {
+            Message::TWITCH(comment) => {
+                let score = f32::max(0.0, calculate_score(comment.message.body.len()));
+                self._shortcut_for_this_comment_user(comment, score)
+            },
+        }
     }
 }
 


### PR DESCRIPTION
Makes `metric` and `metadata` less reliant on `Comment`, which is a Twitch-specific structure.

This change is one part to implement Discord chat elo, part of this task: https://github.com/orgs/vanorsigma/projects/1?pane=issue&itemId=72551296

Changes have been locally tested by running a backfill.