### PR TITLE
Fix percentile function

### DIFF
--- a/rust/elo/src/leaderboards/leaderboardtrait.rs
+++ b/rust/elo/src/leaderboards/leaderboardtrait.rs
@@ -1,6 +1,6 @@
 use crate::_types::clptypes::{BadgeInformation, UserChatPerformance};
 use crate::_types::leaderboardtypes::{LeaderboardExportItem, LeaderboardInnerState};
-use log::{debug, info};
+use log::{debug, info, warn};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -100,7 +100,7 @@ pub trait AbstractLeaderboard {
         // Update rank and delta
         let mut sorted_to_save = to_save.clone();
         sorted_to_save.sort_by(|a, b| b.elo.partial_cmp(&a.elo).unwrap());
-        assert!(sorted_to_save.len() > 1, "Nothing to save!");
+        if sorted_to_save.len() < 1 {warn!("Nothing to save for leaderboard {}", self.get_name())}
 
         let updated_to_save: Vec<LeaderboardExportItem> = sorted_to_save
             .into_iter()

--- a/rust/elo/src/leaderboards/leaderboardtrait.rs
+++ b/rust/elo/src/leaderboards/leaderboardtrait.rs
@@ -165,6 +165,10 @@ pub trait AbstractLeaderboard {
     }
 
     fn percentiles(&self, scores: &[f32], start: f32, end: f32, step: f32) -> Vec<f32> {
+        if scores.is_empty() {
+            return Vec::new();
+        }
+        
         let mut sorted_scores = scores.to_vec();
         sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let step_count = ((end - start) / step) as usize + 1;


### PR DESCRIPTION
Adds an empty list guard to the  ```percentile``` function of leaderboard trait.