### PR TITLE
Moving Emote Processing into SevenTVClient

### DIFF
--- a/rust/chatdownloader/src/backfill.rs
+++ b/rust/chatdownloader/src/backfill.rs
@@ -2,7 +2,10 @@
 A function to backfill given video IDs
 */
 
+use std::sync::Arc;
+
 use log::info;
+use twitch_utils::seventvclient::SevenTVClient;
 
 use crate::chatlogprocessor::ChatLogProcessor;
 use crate::twitchdownloaderproxy::TwitchChatDownloader;
@@ -25,6 +28,7 @@ const VIDEO_IDS: [&str; 12] = [
 
 pub async fn backfill() {
     let twitch = TwitchAPIWrapper::new().await.unwrap();
+    let seventv_client = Arc::new(SevenTVClient::new().await);
     let mut downloader = TwitchChatDownloader::new();
 
     for video_id in VIDEO_IDS.iter() {
@@ -35,7 +39,7 @@ pub async fn backfill() {
             .await
             .expect("Could not download chat log: {e:?}");
 
-        let user_performances = ChatLogProcessor::new(&twitch)
+        let user_performances = ChatLogProcessor::new(&twitch, seventv_client.clone())
             .await
             .process_from_log_object(chat_log)
             .await;

--- a/rust/chatdownloader/src/chatlogprocessor.rs
+++ b/rust/chatdownloader/src/chatlogprocessor.rs
@@ -3,7 +3,9 @@ use elo::_types::clptypes::{Message, UserChatPerformance};
 use elo::leaderboards::LeaderboardProcessor;
 use log::{debug, info};
 use std::fs;
+use std::sync::Arc;
 use std::time::Instant;
+use twitch_utils::seventvclient::SevenTVClient;
 use twitch_utils::TwitchAPIWrapper;
 
 use twitch_utils::twitchtypes::ChatLog;
@@ -21,8 +23,8 @@ pub struct ChatLogProcessor {
 }
 
 impl ChatLogProcessor {
-    pub async fn new(twitch: &TwitchAPIWrapper) -> Self {
-        let message_processor = MessageProcessor::new(twitch).await;
+    pub async fn new(twitch: &TwitchAPIWrapper, seventv_client: Arc<SevenTVClient>) -> Self {
+        let message_processor = MessageProcessor::new(twitch, seventv_client).await;
 
         Self { message_processor }
     }
@@ -52,13 +54,8 @@ impl ChatLogProcessor {
     }
 
     pub async fn process_from_log_object(self, chat_log: ChatLog) -> Vec<UserChatPerformance> {
-        self.process_from_messages(
-            chat_log
-                .comments
-                .into_iter()
-                .map(Message::from),
-        )
-        .await
+        self.process_from_messages(chat_log.comments.into_iter().map(Message::from))
+            .await
     }
 
     #[allow(dead_code)]

--- a/rust/chatdownloader/src/main.rs
+++ b/rust/chatdownloader/src/main.rs
@@ -7,8 +7,8 @@ mod twitchdownloaderproxy;
 use elo::_types::clptypes::Message;
 use env_logger::Env;
 use log::info;
-use std::{env, process::exit};
-use twitch_utils::TwitchAPIWrapper;
+use std::{env, process::exit, sync::Arc};
+use twitch_utils::{seventvclient::SevenTVClient, TwitchAPIWrapper};
 
 const CHANNEL_ID: &str = "1067638175478071307";
 
@@ -66,7 +66,9 @@ async fn main() {
     .into_iter()
     .map(|m| Message::Discord(m));
 
-    let processor = chatlogprocessor::ChatLogProcessor::new(&twitch).await;
+    let seventv_client = Arc::new(SevenTVClient::new().await);
+
+    let processor = chatlogprocessor::ChatLogProcessor::new(&twitch, seventv_client).await;
     // let chat_log = processor.__parse_to_log_struct("chat.json".to_string());
     let user_performances = processor
         .process_from_messages(chat_log.chain(discord_messages))

--- a/rust/elo/src/lib.rs
+++ b/rust/elo/src/lib.rs
@@ -1,10 +1,14 @@
-use std::{collections::HashMap, sync::atomic::AtomicU32};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicU32, Arc},
+};
 
 use _types::clptypes::{Message, MetadataTypes, MetadataUpdate, MetricUpdate, UserChatPerformance};
 use log::{debug, warn};
 use metadata::setup_metadata_and_channels;
 use metrics::setup_metrics_and_channels;
 use tokio::sync::mpsc;
+use twitch_utils::seventvclient::SevenTVClient;
 
 pub mod _constants;
 pub mod _types;
@@ -22,9 +26,12 @@ pub struct MessageProcessor {
 }
 
 impl MessageProcessor {
-    pub async fn new(twitch: &twitch_utils::TwitchAPIWrapper) -> Self {
+    pub async fn new(
+        twitch: &twitch_utils::TwitchAPIWrapper,
+        seventv_client: Arc<SevenTVClient>,
+    ) -> Self {
         let (mut metric_processor, metric_sender, metric_receiver) =
-            setup_metrics_and_channels().await;
+            setup_metrics_and_channels(seventv_client).await;
 
         let (mut metadata_processor, metadata_sender, metadata_receiver) =
             setup_metadata_and_channels(twitch).await;

--- a/rust/elo/src/metrics/bits.rs
+++ b/rust/elo/src/metrics/bits.rs
@@ -6,11 +6,13 @@ const WEIGHT_BITS: f32 = 0.1;
 #[derive(Default, Debug)]
 pub struct Bits;
 
-impl AbstractMetric for Bits {
-    async fn new() -> Self {
-        Self
+impl Bits {
+    pub fn new() -> Self {
+        Self {}
     }
+}
 
+impl AbstractMetric for Bits {
     fn can_parallelize(&self) -> bool {
         true
     }

--- a/rust/elo/src/metrics/copypastaleader.rs
+++ b/rust/elo/src/metrics/copypastaleader.rs
@@ -14,6 +14,14 @@ pub struct CopypastaLeader {
 }
 
 impl CopypastaLeader {
+    pub fn new() -> Self {
+        Self {
+            history: Vec::new(),
+        }
+    }
+}
+
+impl CopypastaLeader {
     fn get_metric_for_twitch_message(
         &mut self,
         comment: Comment,
@@ -108,12 +116,6 @@ impl CopypastaLeader {
 }
 
 impl AbstractMetric for CopypastaLeader {
-    async fn new() -> Self {
-        Self {
-            history: Vec::new(),
-        }
-    }
-
     fn can_parallelize(&self) -> bool {
         false
     }

--- a/rust/elo/src/metrics/emote.rs
+++ b/rust/elo/src/metrics/emote.rs
@@ -1,5 +1,4 @@
 //! The emote metric
-use core::panic;
 use std::sync::Arc;
 
 use crate::_types::clptypes::{Message, MetricUpdate};
@@ -10,22 +9,18 @@ use super::metrictrait::AbstractMetric;
 const WEIGHT_EMOTES: f32 = 0.02;
 
 pub struct Emote {
-    seventv_client: Option<Arc<SevenTVClient>>,
+    seventv_client: Arc<SevenTVClient>,
 }
 
 impl Emote {
-    pub fn set_seventv_client(&mut self, client: Arc<SevenTVClient>) {
-        self.seventv_client = Some(client);
+    pub fn new(seventv_client: Arc<SevenTVClient>) -> Self {
+        Self {
+            seventv_client,
+        }
     }
 }
 
 impl AbstractMetric for Emote {
-    async fn new() -> Self {
-        Self {
-            seventv_client: None,
-        }
-    }
-
     fn can_parallelize(&self) -> bool {
         false
     }
@@ -39,8 +34,6 @@ impl AbstractMetric for Emote {
             Message::Twitch(comment) => {
                 let score: f32 = self
                     .seventv_client
-                    .as_ref()
-                    .unwrap_or_else(|| panic!("7TV client not set"))
                     .get_emotes_in_comment(&comment)
                     .len() as f32
                     * WEIGHT_EMOTES;

--- a/rust/elo/src/metrics/emote.rs
+++ b/rust/elo/src/metrics/emote.rs
@@ -1,87 +1,28 @@
 //! The emote metric
-use std::collections::HashSet;
+use core::panic;
+use std::sync::Arc;
 
-use lazy_static::lazy_static;
-use log::{debug, info};
-use serde::Deserialize;
-
-use crate::_types::clptypes::MetricUpdate;
-use crate::{_constants::VED_CH_ID, _types::clptypes::Message};
-use twitch_utils::twitchtypes::ChatMessageFragment;
+use crate::_types::clptypes::{Message, MetricUpdate};
+use twitch_utils::seventvclient::SevenTVClient;
 
 use super::metrictrait::AbstractMetric;
 
 const WEIGHT_EMOTES: f32 = 0.02;
 
-lazy_static! {
-    static ref SEVEN_TV_URL: String = format!("https://7tv.io/v3/users/twitch/{}", VED_CH_ID);
-}
-
-#[derive(Deserialize)]
-struct SevenTVEmote {
-    name: String,
-    #[allow(dead_code)]
-    emote_url: String,
-}
-
 pub struct Emote {
-    #[allow(dead_code)]
-    seventv_emotes: Vec<SevenTVEmote>,
-    seventv_lookup: HashSet<String>,
+    seventv_client: Option<Arc<SevenTVClient>>,
 }
 
 impl Emote {
-    fn count_7tv_emotes_in_fragment(&self, fragment: &ChatMessageFragment) -> usize {
-        let mut count = 0;
-        for word in fragment.text.split(' ') {
-            if self.seventv_lookup.contains(word) {
-                count += 1;
-            }
-        }
-        debug!("Found {} number of 7TV emotes in {}", count, fragment.text);
-        count
+    pub fn set_seventv_client(&mut self, client: Arc<SevenTVClient>) {
+        self.seventv_client = Some(client);
     }
 }
 
 impl AbstractMetric for Emote {
     async fn new() -> Self {
-        info!("Getting the 7TV channel emotes");
-        let response = reqwest::get(SEVEN_TV_URL.clone()).await;
-        if response.is_err() {
-            info!("Cannot get 7tv emotes");
-            return Self {
-                seventv_emotes: Vec::new(),
-                seventv_lookup: HashSet::new(),
-            };
-        }
-
-        let resp_body: serde_json::Value = response.unwrap().json().await.unwrap();
-        let mut ret_val = Vec::new();
-        if let Some(raw_emotes) = resp_body["emote_set"]["emotes"].as_array() {
-            for raw_emote in raw_emotes {
-                let host_url = raw_emote["data"]["host"]["url"].as_str().unwrap();
-                let filename = raw_emote["data"]["host"]["files"]
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .filter(|emote| emote["name"].as_str().unwrap().ends_with(".webp"))
-                    .max_by_key(|emote| emote["width"].as_i64().unwrap())
-                    .unwrap();
-                ret_val.push(SevenTVEmote {
-                    name: raw_emote["name"].as_str().unwrap().to_owned(),
-                    emote_url: format!("https://{}/{}", host_url, filename["name"]),
-                });
-            }
-        } else {
-            info!("Cannot access the required keys to get the emotes");
-        }
-
-        debug!("Got {} 7tv emotes", ret_val.len());
-        let seventv_lookup: HashSet<String> =
-            ret_val.iter().map(|emote| emote.name.clone()).collect();
         Self {
-            seventv_emotes: ret_val,
-            seventv_lookup,
+            seventv_client: None,
         }
     }
 
@@ -96,16 +37,13 @@ impl AbstractMetric for Emote {
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         match message {
             Message::Twitch(comment) => {
-                let score: f32 = comment
-                    .message
-                    .fragments
-                    .iter()
-                    .map(|fragment| {
-                        (fragment.emoticon.is_some() as u16 as f32
-                            + self.count_7tv_emotes_in_fragment(fragment) as f32)
-                            * WEIGHT_EMOTES
-                    })
-                    .sum();
+                let score: f32 = self
+                    .seventv_client
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("7TV client not set"))
+                    .get_emotes_in_comment(&comment)
+                    .len() as f32
+                    * WEIGHT_EMOTES;
                 self.twitch_comment_shortcut(comment, score)
             }
             _ => MetricUpdate::empty_with_name(self.get_name()), // TODO: discord emotes

--- a/rust/elo/src/metrics/metrictrait.rs
+++ b/rust/elo/src/metrics/metrictrait.rs
@@ -4,11 +4,6 @@ use twitch_utils::twitchtypes::Comment;
 
 /// Defines the trait for a metric
 pub trait AbstractMetric {
-    /// Initializes the metric
-    async fn new() -> Self
-    where
-        Self: Sized;
-
     fn twitch_comment_shortcut(&self, comment: Comment, score: f32) -> MetricUpdate {
         let mut map: HashMap<String, f32> = HashMap::new();
         map.insert(comment.commenter._id, score);

--- a/rust/elo/src/metrics/mod.rs
+++ b/rust/elo/src/metrics/mod.rs
@@ -39,13 +39,11 @@ impl MetricProcessor {
     ) -> Self {
         let mut defaults: HashMap<String, f32> = HashMap::new();
 
-        let bits = bits::Bits::new().await;
-        let subs = subs::Subs::new().await;
-        let text = text::Text::new().await;
-        let copypastaleader = copypastaleader::CopypastaLeader::new().await;
-        let mut emote = emote::Emote::new().await;
-
-        emote.set_seventv_client(seventv_client);
+        let bits = bits::Bits::new();
+        let subs = subs::Subs::new();
+        let text = text::Text::new();
+        let copypastaleader = copypastaleader::CopypastaLeader::new();
+        let emote = emote::Emote::new(seventv_client);
 
         defaults.insert(bits.get_name(), 0.0);
         defaults.insert(subs.get_name(), 0.0);

--- a/rust/elo/src/metrics/subs.rs
+++ b/rust/elo/src/metrics/subs.rs
@@ -20,11 +20,13 @@ lazy_static! {
 #[derive(Default, Debug)]
 pub struct Subs;
 
-impl AbstractMetric for Subs {
-    async fn new() -> Self {
-        Self
+impl Subs {
+    pub fn new() -> Self {
+        Self {}
     }
+}
 
+impl AbstractMetric for Subs {
     fn can_parallelize(&self) -> bool {
         true
     }

--- a/rust/elo/src/metrics/text.rs
+++ b/rust/elo/src/metrics/text.rs
@@ -9,11 +9,13 @@ const WEIGHT_TEXT: f32 = 0.02;
 #[derive(Default, Debug)]
 pub struct Text;
 
-impl AbstractMetric for Text {
-    async fn new() -> Self {
-        Self
+impl Text {
+    pub fn new() -> Self {
+        Self {}
     }
+}
 
+impl AbstractMetric for Text {
     fn can_parallelize(&self) -> bool {
         false
     }

--- a/rust/twitch_utils/Cargo.toml
+++ b/rust/twitch_utils/Cargo.toml
@@ -10,3 +10,5 @@ serde = { version = "1.0.204", features = ["derive"] }
 twitch_api = { version = "0.7.0-rc.7", features = ["all", "reqwest"] }
 chrono = "0.4.38"
 regex = "1.10.6"
+lazy_static = "1.5.0"
+serde_json = "1.0.125"

--- a/rust/twitch_utils/src/lib.rs
+++ b/rust/twitch_utils/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod seventvclient;
+
 use std::collections::HashMap;
 
 use chrono::{DateTime, FixedOffset};

--- a/rust/twitch_utils/src/lib.rs
+++ b/rust/twitch_utils/src/lib.rs
@@ -1,5 +1,3 @@
-pub mod seventvclient;
-
 use std::collections::HashMap;
 
 use chrono::{DateTime, FixedOffset};
@@ -9,6 +7,8 @@ use twitch_api::helix::videos::GetVideosRequest;
 use twitch_api::twitch_oauth2::{AppAccessToken, ClientId, ClientSecret};
 use twitch_api::HelixClient;
 
+pub mod seventvclient;
+pub mod seventvtypes;
 pub mod twitchtypes;
 
 pub const USER_AGENT: &str = concat!(

--- a/rust/twitch_utils/src/seventvclient.rs
+++ b/rust/twitch_utils/src/seventvclient.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, vec};
+use std::collections::HashSet;
 use crate::seventvtypes::SevenTVResponse;
 
 use log::{debug, info};
@@ -32,7 +32,7 @@ impl SevenTVClient {
             .iter()
             .map(|emote| SevenTVEmote::from(emote.clone()))
             .collect();
-        
+
         let seventv_lookup: HashSet<String> = seventv_emotes
             .iter()
             .map(|emote| emote.name.clone())

--- a/rust/twitch_utils/src/seventvclient.rs
+++ b/rust/twitch_utils/src/seventvclient.rs
@@ -1,15 +1,11 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, vec};
+use crate::seventvtypes::SevenTVResponse;
 
-use lazy_static::lazy_static;
 use log::{debug, info};
 
 use crate::twitchtypes::{ChatMessageFragment, Comment, SevenTVEmote, TwitchEmote};
 
-const VED_CH_ID: &str = "85498365";
-
-lazy_static! {
-    static ref SEVEN_TV_URL: String = format!("https://7tv.io/v3/users/twitch/{}", VED_CH_ID);
-}
+const SEVEN_TV_URL: &str = "https://7tv.io/v3/users/twitch/85498365";
 
 #[derive(Default)]
 pub struct SevenTVClient {
@@ -20,7 +16,7 @@ pub struct SevenTVClient {
 impl SevenTVClient {
     pub async fn new() -> Self {
         info!("Getting the 7TV channel emotes");
-        let response = reqwest::get(SEVEN_TV_URL.clone()).await;
+        let response = reqwest::get(SEVEN_TV_URL).await;
         if response.is_err() {
             info!("Cannot get 7tv emotes");
             return Self {
@@ -29,33 +25,21 @@ impl SevenTVClient {
             };
         }
 
-        let resp_body: serde_json::Value = response.unwrap().json().await.unwrap();
-        let mut ret_val = Vec::new();
-        if let Some(raw_emotes) = resp_body["emote_set"]["emotes"].as_array() {
-            for raw_emote in raw_emotes {
-                let host_url = raw_emote["data"]["host"]["url"].as_str().unwrap();
-                let filename = raw_emote["data"]["host"]["files"]
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .filter(|emote| emote["name"].as_str().unwrap().ends_with(".webp"))
-                    .max_by_key(|emote| emote["width"].as_i64().unwrap())
-                    .unwrap();
-                ret_val.push(SevenTVEmote {
-                    id: raw_emote["id"].as_str().unwrap().to_owned(),
-                    name: raw_emote["name"].as_str().unwrap().to_owned(),
-                    emote_url: format!("https:{}/{}", host_url, filename["name"].as_str().unwrap()),
-                });
-            }
-        } else {
-            info!("Cannot access the required keys to get the emotes");
-        }
+        let response: SevenTVResponse = response.unwrap().json::<SevenTVResponse>().await.unwrap();
+        let seventv_emotes: Vec<SevenTVEmote> = response.emote_set
+            .emotes
+            .data
+            .iter()
+            .map(|emote| SevenTVEmote::from(emote.clone()))
+            .collect();
+        
+        let seventv_lookup: HashSet<String> = seventv_emotes
+            .iter()
+            .map(|emote| emote.name.clone())
+            .collect();
 
-        debug!("Got {} 7tv emotes", ret_val.len());
-        let seventv_lookup: HashSet<String> =
-            ret_val.iter().map(|emote| emote.name.clone()).collect();
         Self {
-            seventv_emotes: ret_val,
+            seventv_emotes,
             seventv_lookup,
         }
     }
@@ -76,19 +60,13 @@ impl SevenTVClient {
     }
 
     pub fn get_emotes_in_fragment(&self, fragment: &ChatMessageFragment) -> Vec<TwitchEmote> {
-        let mut emotes: Vec<TwitchEmote> = Vec::new();
-        if let Some(emote) = &fragment.emoticon {
-            emotes.push(TwitchEmote::from_twitch_name_id(
-                fragment.text.clone(),
-                emote.emoticon_id.clone(),
-            ));
-        }
-        emotes.extend(
-            self.get_7tv_emotes_in_fragment(fragment)
-                .iter()
-                .map(|emote| TwitchEmote::from(emote.clone())),
-        );
-        emotes
+        self.get_7tv_emotes_in_fragment(fragment)
+            .iter()
+            .map(|emote| TwitchEmote::from(emote.clone()))
+            .chain(fragment.emoticon.iter().map(|s| {
+                TwitchEmote::from_twitch_name_id(fragment.text.clone(), s.emoticon_id.clone())
+            }))
+            .collect()
     }
 
     pub fn get_emotes_in_comment(&self, comment: &Comment) -> Vec<TwitchEmote> {

--- a/rust/twitch_utils/src/seventvclient.rs
+++ b/rust/twitch_utils/src/seventvclient.rs
@@ -1,0 +1,108 @@
+use std::collections::HashSet;
+
+use lazy_static::lazy_static;
+use log::{debug, info};
+
+use crate::twitchtypes::{ChatMessageFragment, Comment, SevenTVEmote, TwitchEmote};
+
+const VED_CH_ID: &str = "85498365";
+
+lazy_static! {
+    static ref SEVEN_TV_URL: String = format!("https://7tv.io/v3/users/twitch/{}", VED_CH_ID);
+}
+
+#[derive(Default)]
+pub struct SevenTVClient {
+    seventv_emotes: Vec<SevenTVEmote>,
+    seventv_lookup: HashSet<String>,
+}
+
+impl SevenTVClient {
+    pub async fn new() -> Self {
+        info!("Getting the 7TV channel emotes");
+        let response = reqwest::get(SEVEN_TV_URL.clone()).await;
+        if response.is_err() {
+            info!("Cannot get 7tv emotes");
+            return Self {
+                seventv_emotes: Vec::new(),
+                seventv_lookup: HashSet::new(),
+            };
+        }
+
+        let resp_body: serde_json::Value = response.unwrap().json().await.unwrap();
+        let mut ret_val = Vec::new();
+        if let Some(raw_emotes) = resp_body["emote_set"]["emotes"].as_array() {
+            for raw_emote in raw_emotes {
+                let host_url = raw_emote["data"]["host"]["url"].as_str().unwrap();
+                let filename = raw_emote["data"]["host"]["files"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .filter(|emote| emote["name"].as_str().unwrap().ends_with(".webp"))
+                    .max_by_key(|emote| emote["width"].as_i64().unwrap())
+                    .unwrap();
+                ret_val.push(SevenTVEmote {
+                    id: raw_emote["id"].as_str().unwrap().to_owned(),
+                    name: raw_emote["name"].as_str().unwrap().to_owned(),
+                    emote_url: format!("https:{}/{}", host_url, filename["name"].as_str().unwrap()),
+                });
+            }
+        } else {
+            info!("Cannot access the required keys to get the emotes");
+        }
+
+        debug!("Got {} 7tv emotes", ret_val.len());
+        let seventv_lookup: HashSet<String> =
+            ret_val.iter().map(|emote| emote.name.clone()).collect();
+        Self {
+            seventv_emotes: ret_val,
+            seventv_lookup,
+        }
+    }
+
+    pub fn get_7tv_emotes_in_fragment(&self, fragment: &ChatMessageFragment) -> Vec<SevenTVEmote> {
+        fragment
+            .text
+            .split(' ')
+            .filter(|word| self.seventv_lookup.contains(*word))
+            .map(|word| {
+                self.seventv_emotes
+                    .iter()
+                    .find(|e| e.name == word)
+                    .unwrap()
+                    .clone()
+            })
+            .collect()
+    }
+
+    pub fn get_emotes_in_fragment(&self, fragment: &ChatMessageFragment) -> Vec<TwitchEmote> {
+        let mut emotes: Vec<TwitchEmote> = Vec::new();
+        if let Some(emote) = &fragment.emoticon {
+            emotes.push(TwitchEmote::from_twitch_name_id(
+                fragment.text.clone(),
+                emote.emoticon_id.clone(),
+            ));
+        }
+        emotes.extend(
+            self.get_7tv_emotes_in_fragment(fragment)
+                .iter()
+                .map(|emote| TwitchEmote::from(emote.clone())),
+        );
+        emotes
+    }
+
+    pub fn get_emotes_in_comment(&self, comment: &Comment) -> Vec<TwitchEmote> {
+        let emotes: Vec<TwitchEmote> = comment
+            .message
+            .fragments
+            .iter()
+            .flat_map(|fragment| self.get_emotes_in_fragment(fragment))
+            .collect();
+        debug!(
+            "Got {:?} emotes in comment: {}",
+            emotes.len(),
+            comment.message.body
+        );
+        emotes
+    }
+}

--- a/rust/twitch_utils/src/seventvtypes.rs
+++ b/rust/twitch_utils/src/seventvtypes.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SevenTVResponse {
+    pub emote_set: SevenTVEmoteSet,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SevenTVEmoteSet {
+    pub emotes: SevenTVEmotesBundle,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SevenTVEmotesBundle {
+    pub data: Vec<RawSevenTVEmote>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RawSevenTVEmote {
+    pub id: String,
+    pub name: String,
+    pub host: SevenTVEmoteHost,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SevenTVEmoteHost {
+    pub url: String,
+    pub files: Vec<SevenTVEmoteFile>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SevenTVEmoteFile {
+    pub name: String,
+    pub static_name: String,
+    pub width: i64,
+}

--- a/rust/twitch_utils/src/twitchtypes.rs
+++ b/rust/twitch_utils/src/twitchtypes.rs
@@ -3,6 +3,71 @@ Contains all the Twitch types parsable from the chat log
 */
 
 use serde::{Deserialize, Serialize};
+use twitch_api::helix::chat::{ChannelEmote, GlobalEmote};
+
+const TWITCH_EMOTE_URL: &str = "https://static-cdn.jtvnw.net/emoticons/v2";
+const TWITCH_EMOTE_URL_ENDING: &str = "default/light/1.0";
+
+#[derive(Debug, Clone)]
+pub struct TwitchEmote {
+    pub id: String,
+    pub name: String,
+    pub url: String,
+}
+
+impl TwitchEmote {
+    pub fn new(id: String, name: String, url: String) -> Self {
+        Self { id, name, url }
+    }
+
+    /// Helper function for creating a TwitchEmote from a Twitch emote name and id.
+    ///
+    /// Used for extracting emotes from a ChatLog without contacting the API
+    pub fn from_twitch_name_id(name: String, id: String) -> Self {
+        Self {
+            id: id.clone(),
+            name,
+            url: format!("{}/{}/{}", TWITCH_EMOTE_URL, id, TWITCH_EMOTE_URL_ENDING),
+        }
+    }
+}
+
+impl From<SevenTVEmote> for TwitchEmote {
+    fn from(seventv_emote: SevenTVEmote) -> Self {
+        Self {
+            id: seventv_emote.id,
+            name: seventv_emote.name,
+            url: seventv_emote.emote_url,
+        }
+    }
+}
+
+impl From<&GlobalEmote> for TwitchEmote {
+    fn from(global_emote: &GlobalEmote) -> Self {
+        Self {
+            id: global_emote.id.to_string(),
+            name: global_emote.name.clone(),
+            url: global_emote.images.url_4x.clone(),
+        }
+    }
+}
+
+impl From<&ChannelEmote> for TwitchEmote {
+    fn from(channel_emote: &ChannelEmote) -> Self {
+        Self {
+            id: channel_emote.id.to_string(),
+            name: channel_emote.name.clone(),
+            url: channel_emote.images.url_4x.clone(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct SevenTVEmote {
+    pub id: String,
+    pub name: String,
+    pub emote_url: String,
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ChatMessageFragmentEmoticon {

--- a/rust/twitch_utils/src/twitchtypes.rs
+++ b/rust/twitch_utils/src/twitchtypes.rs
@@ -4,6 +4,7 @@ Contains all the Twitch types parsable from the chat log
 
 use serde::{Deserialize, Serialize};
 use twitch_api::helix::chat::{ChannelEmote, GlobalEmote};
+use crate::seventvtypes::RawSevenTVEmote;
 
 const TWITCH_EMOTE_URL: &str = "https://static-cdn.jtvnw.net/emoticons/v2";
 const TWITCH_EMOTE_URL_ENDING: &str = "default/light/1.0";
@@ -42,22 +43,32 @@ impl From<SevenTVEmote> for TwitchEmote {
     }
 }
 
-impl From<&GlobalEmote> for TwitchEmote {
-    fn from(global_emote: &GlobalEmote) -> Self {
+impl From<GlobalEmote> for TwitchEmote {
+    fn from(global_emote: GlobalEmote) -> Self {
         Self {
             id: global_emote.id.to_string(),
-            name: global_emote.name.clone(),
-            url: global_emote.images.url_4x.clone(),
+            name: global_emote.name,
+            url: global_emote.images.url_4x,
         }
     }
 }
 
-impl From<&ChannelEmote> for TwitchEmote {
-    fn from(channel_emote: &ChannelEmote) -> Self {
+impl From<ChannelEmote> for TwitchEmote {
+    fn from(channel_emote: ChannelEmote) -> Self {
         Self {
             id: channel_emote.id.to_string(),
-            name: channel_emote.name.clone(),
-            url: channel_emote.images.url_4x.clone(),
+            name: channel_emote.name,
+            url: channel_emote.images.url_4x,
+        }
+    }
+}
+
+impl From<RawSevenTVEmote> for SevenTVEmote {
+    fn from(raw_emote: RawSevenTVEmote) -> Self {
+        Self {
+            id: raw_emote.id,
+            name: raw_emote.name,
+            emote_url: raw_emote.host.url,
         }
     }
 }


### PR DESCRIPTION
# Changes

This PR prepares for the implementation of a most used emote leaderboard. Access to 7TV emotes and functions related to them will be required by 2 metrics (includes the existing emotes metric) and 1 metadata. 

As such, this PR moves 7TV into its own struct in the `twitch_utils` crate. The struct lives in an Arc reference which will be cloned and passed to all services that need it.

## Related Cards

- https://github.com/orgs/vanorsigma/projects/1/views/1?pane=issue&itemId=76010173
