### PR TITLE
Remove the constructor from MetadataTrait

### DIFF
--- a/rust/elo/src/metadata/badges.rs
+++ b/rust/elo/src/metadata/badges.rs
@@ -63,6 +63,33 @@ pub struct Badges {
 }
 
 impl Badges {
+    pub async fn new(twitch: &TwitchAPIWrapper) -> Self {
+        let badges = twitch
+            .get_badges(VED_CH_ID.to_string())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(set_id, badge_set)| {
+                (
+                    set_id.clone(),
+                    badge_set
+                        .into_iter()
+                        .map(|(badge_id, badge)| {
+                            (
+                                badge_id,
+                                BadgeInformation {
+                                    description: set_id.clone(),
+                                    image_url: badge.image_url_4x,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+        Self { badges }
+    }
+
     fn get_metadata_twitch(&self, comment: Comment) -> MetadataUpdate {
         let mut metadata: Vec<BadgeInformation> = vec![];
         let user_badges = if let Some(user_badges) = comment.message.user_badges {
@@ -127,33 +154,6 @@ impl Badges {
 }
 
 impl AbstractMetadata for Badges {
-    async fn new(twitch: &TwitchAPIWrapper) -> Self {
-        let badges = twitch
-            .get_badges(VED_CH_ID.to_string())
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(set_id, badge_set)| {
-                (
-                    set_id.clone(),
-                    badge_set
-                        .into_iter()
-                        .map(|(badge_id, badge)| {
-                            (
-                                badge_id,
-                                BadgeInformation {
-                                    description: set_id.clone(),
-                                    image_url: badge.image_url_4x,
-                                },
-                            )
-                        })
-                        .collect(),
-                )
-            })
-            .collect();
-        Self { badges }
-    }
-
     fn get_name(&self) -> String {
         "badges".to_string()
     }

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -42,7 +42,7 @@ impl AbstractMetadata for BasicInfo {
 }
 
 impl BasicInfo {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         Self
     }
 }

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -3,17 +3,12 @@ use std::collections::HashMap;
 
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
-use twitch_utils::TwitchAPIWrapper;
 
 /// Figures out if the user is a special role
 #[derive(Default, Debug)]
 pub struct BasicInfo;
 
 impl AbstractMetadata for BasicInfo {
-    async fn new(_twitch: &TwitchAPIWrapper) -> Self {
-        Self
-    }
-
     fn get_name(&self) -> String {
         "basic_info".to_string()
     }
@@ -43,5 +38,11 @@ impl AbstractMetadata for BasicInfo {
             },
             _ => MetadataUpdate::default(),
         }
+    }
+}
+
+impl BasicInfo {
+    pub async fn new() -> Self {
+        Self
     }
 }

--- a/rust/elo/src/metadata/chat_origin.rs
+++ b/rust/elo/src/metadata/chat_origin.rs
@@ -3,17 +3,12 @@ use std::collections::HashMap;
 
 use crate::_types::clptypes::{Message, MessageTag, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
-use twitch_utils::TwitchAPIWrapper;
 
 /// Figures out the association of a message to a chat origin
 #[derive(Default, Debug)]
 pub struct ChatOrigin;
 
 impl AbstractMetadata for ChatOrigin {
-    async fn new(_twitch: &TwitchAPIWrapper) -> Self {
-        Self
-    }
-
     fn get_name(&self) -> String {
         "chat_origin".to_string()
     }
@@ -35,5 +30,11 @@ impl AbstractMetadata for ChatOrigin {
                 MetadataTypes::ChatOrigin(MessageTag::from(&message)),
             )]),
         }
+    }
+}
+
+impl ChatOrigin {
+    pub async fn new() -> Self {
+        Self
     }
 }

--- a/rust/elo/src/metadata/chat_origin.rs
+++ b/rust/elo/src/metadata/chat_origin.rs
@@ -34,7 +34,7 @@ impl AbstractMetadata for ChatOrigin {
 }
 
 impl ChatOrigin {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         Self
     }
 }

--- a/rust/elo/src/metadata/metadatatrait.rs
+++ b/rust/elo/src/metadata/metadatatrait.rs
@@ -1,6 +1,5 @@
 //! Represents an abstract metadata
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
-use twitch_utils::TwitchAPIWrapper;
 
 pub trait AbstractMetadata: Sized {
     /*
@@ -9,11 +8,6 @@ pub trait AbstractMetadata: Sized {
     Struct should ensure to set self.twtich to the twitch object passed
     if it needs to make API calls
     */
-
-    /// Creates a new metadata object
-    async fn new(twitch: &TwitchAPIWrapper) -> Self
-    where
-        Self: Sized + Send;
 
     /// Name of this piece of metadata
     fn get_name(&self) -> String;

--- a/rust/elo/src/metadata/mod.rs
+++ b/rust/elo/src/metadata/mod.rs
@@ -36,10 +36,10 @@ impl MetadataProcessor {
         let mut defaults: HashMap<String, MetadataTypes> = HashMap::new();
 
         // Initialize the metadata
-        let basic_info = basic_info::BasicInfo::new();
+        let basic_info = basic_info::BasicInfo::new().await;
         let badges = badges::Badges::new(twitch).await;
-        let special_role = special_role::SpecialRole::new();
-        let chat_origin = chat_origin::ChatOrigin::new();
+        let special_role = special_role::SpecialRole::new().await;
+        let chat_origin = chat_origin::ChatOrigin::new().await;
 
         // Add names and default values to the metadata
         defaults.insert(basic_info.get_name(), basic_info.get_default_value());

--- a/rust/elo/src/metadata/mod.rs
+++ b/rust/elo/src/metadata/mod.rs
@@ -36,10 +36,10 @@ impl MetadataProcessor {
         let mut defaults: HashMap<String, MetadataTypes> = HashMap::new();
 
         // Initialize the metadata
-        let basic_info = basic_info::BasicInfo::new().await;
+        let basic_info = basic_info::BasicInfo::new();
         let badges = badges::Badges::new(twitch).await;
-        let special_role = special_role::SpecialRole::new().await;
-        let chat_origin = chat_origin::ChatOrigin::new().await;
+        let special_role = special_role::SpecialRole::new();
+        let chat_origin = chat_origin::ChatOrigin::new();
 
         // Add names and default values to the metadata
         defaults.insert(basic_info.get_name(), basic_info.get_default_value());

--- a/rust/elo/src/metadata/mod.rs
+++ b/rust/elo/src/metadata/mod.rs
@@ -36,10 +36,10 @@ impl MetadataProcessor {
         let mut defaults: HashMap<String, MetadataTypes> = HashMap::new();
 
         // Initialize the metadata
-        let basic_info = basic_info::BasicInfo::new(twitch).await;
+        let basic_info = basic_info::BasicInfo::new();
         let badges = badges::Badges::new(twitch).await;
-        let special_role = special_role::SpecialRole::new(twitch).await;
-        let chat_origin = chat_origin::ChatOrigin::new(twitch).await;
+        let special_role = special_role::SpecialRole::new();
+        let chat_origin = chat_origin::ChatOrigin::new();
 
         // Add names and default values to the metadata
         defaults.insert(basic_info.get_name(), basic_info.get_default_value());
@@ -93,14 +93,10 @@ async fn calc_metadata<M: AbstractMetadata + Send + Sync + 'static>(
     /*
     Find metadata based on chat messages sent by a tokio broadcast channel
     */
-    loop {
-        if let Ok((message, sequence_no)) = reciever.recv().await {
-            let metadata = (*metadata).get_metadata(message, sequence_no);
-            if let Err(e) = sender.send(metadata).await {
-                warn!("Failed to send metadata result {}", e)
-            };
-        } else {
-            break;
+    while let Ok((message, sequence_no)) = reciever.recv().await {
+        let metadata = (*metadata).get_metadata(message, sequence_no);
+        if let Err(e) = sender.send(metadata).await {
+            warn!("Failed to send metadata result {}", e)
         };
     }
 }

--- a/rust/elo/src/metadata/special_role.rs
+++ b/rust/elo/src/metadata/special_role.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate, MetricUpdate};
+use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
 use discord_utils::DiscordMessage;
 use twitch_utils::twitchtypes::Comment;
-use twitch_utils::TwitchAPIWrapper;
 
 const SPECIAL_ROLES_TWITCH: [&str; 3] = ["moderator", "vip", "broadcaster"];
 const SPECIAL_ROLES_DISCORD: [&str; 3] = ["Admin", "Moderator", "Twitch Mod"];
@@ -14,6 +13,10 @@ const SPECIAL_ROLES_DISCORD: [&str; 3] = ["Admin", "Moderator", "Twitch Mod"];
 pub struct SpecialRole;
 
 impl SpecialRole {
+    pub async fn new() -> Self {
+        Self
+    }
+
     fn get_metadata_twitch(&self, comment: Comment) -> MetadataUpdate {
         let mut metadata: HashMap<String, MetadataTypes> = HashMap::new();
         let user_badges = comment.message.user_badges;
@@ -56,10 +59,6 @@ impl SpecialRole {
 }
 
 impl AbstractMetadata for SpecialRole {
-    async fn new(_twitch: &TwitchAPIWrapper) -> Self {
-        Self
-    }
-
     fn get_name(&self) -> String {
         "special_role".to_string()
     }

--- a/rust/elo/src/metadata/special_role.rs
+++ b/rust/elo/src/metadata/special_role.rs
@@ -13,7 +13,7 @@ const SPECIAL_ROLES_DISCORD: [&str; 3] = ["Admin", "Moderator", "Twitch Mod"];
 pub struct SpecialRole;
 
 impl SpecialRole {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         Self
     }
 


### PR DESCRIPTION
# Changes

This PR moves the constructor for metadata structs out of `AbstractMetadata` and into each structs' implementation. This is to support the injection of either `SevenTVClient` or `TwitchAPIWrapper` following the advice for #20.

I've left all constuctors as async, however only one metadata (`badges`) needs to be async. Is it better to maintain uniformity and keep everything async, or have the other constructors be non-async?

## Related Cards

- https://github.com/orgs/vanorsigma/projects/1?pane=issue&itemId=76010173