### PR TITLE
Top Emotes Leaderboard

### DIFF
--- a/rust/chatdownloader/src/main.rs
+++ b/rust/chatdownloader/src/main.rs
@@ -43,7 +43,7 @@ async fn main() {
         .expect("Failed to download chat")
         .comments
         .into_iter()
-        .map(|c| Message::Twitch(c));
+        .map(Message::Twitch);
 
     let discord_messages = match env::var("CHAT_DISCORD_TOKEN") {
         Ok(token) => {
@@ -64,7 +64,7 @@ async fn main() {
         }
     }
     .into_iter()
-    .map(|m| Message::Discord(m));
+    .map(Message::Discord);
 
     let seventv_client = Arc::new(SevenTVClient::new().await);
 

--- a/rust/elo/src/_types/clptypes.rs
+++ b/rust/elo/src/_types/clptypes.rs
@@ -1,7 +1,7 @@
 use crate::_types::leaderboardtypes::BadgeInformation;
 use discord_utils::DiscordMessage;
 use std::collections::HashMap;
-use twitch_utils::twitchtypes::Comment;
+use twitch_utils::twitchtypes::{Comment, TwitchEmote};
 
 #[derive(Debug, Clone)]
 pub struct UserChatPerformance {
@@ -110,7 +110,17 @@ macro_rules! declare_messages {
                 }
             }
         }
+
+        impl From<&TwitchEmote> for MessageTag {
+            fn from(_emote: &TwitchEmote) -> Self {
+                Self::TwitchEmote
+            }
+        }
     };
 }
 
-declare_messages!((Twitch, Comment), (Discord, DiscordMessage));
+declare_messages!(
+    (Twitch, Comment),
+    (Discord, DiscordMessage),
+    (TwitchEmote, TwitchEmote)
+);

--- a/rust/elo/src/_types/clptypes.rs
+++ b/rust/elo/src/_types/clptypes.rs
@@ -110,17 +110,11 @@ macro_rules! declare_messages {
                 }
             }
         }
-
-        impl From<&TwitchEmote> for MessageTag {
-            fn from(_emote: &TwitchEmote) -> Self {
-                Self::TwitchEmote
-            }
-        }
     };
 }
 
 declare_messages!(
     (Twitch, Comment),
     (Discord, DiscordMessage),
-    (TwitchEmote, TwitchEmote)
+    (Emote, TwitchEmote)
 );

--- a/rust/elo/src/leaderboards/mod.rs
+++ b/rust/elo/src/leaderboards/mod.rs
@@ -7,6 +7,7 @@ mod nonvips;
 mod overall;
 mod partnersonly;
 mod subsonly;
+mod topemote;
 
 use futures::join;
 
@@ -41,6 +42,7 @@ pub struct LeaderboardProcessor {
     nonvips: nonvips::NonVIPS,
     overall: overall::Overall,
     subsonly: subsonly::SubsOnly,
+    topemote: topemote::TopEmote,
     discordlivestreamchat: discordlivestreamchat::DiscordLivestreamChat,
     partnersonly: partnersonly::PartnersOnly,
 }
@@ -53,6 +55,7 @@ impl LeaderboardProcessor {
         let nonvips = nonvips::NonVIPS::new();
         let overall = overall::Overall::new();
         let subsonly = subsonly::SubsOnly::new();
+        let topemote = topemote::TopEmote::new();
         let discordlivestreamchat = discordlivestreamchat::DiscordLivestreamChat::new();
         let partnersonly = partnersonly::PartnersOnly::new();
 
@@ -63,6 +66,7 @@ impl LeaderboardProcessor {
             nonvips,
             overall,
             subsonly,
+            topemote,
             discordlivestreamchat,
             partnersonly,
         }
@@ -79,6 +83,7 @@ impl LeaderboardProcessor {
             calc_leaderboard(&mut self.nonvips, broadcast_reciever.resubscribe()),
             calc_leaderboard(&mut self.overall, broadcast_reciever.resubscribe()),
             calc_leaderboard(&mut self.subsonly, broadcast_reciever.resubscribe()),
+            calc_leaderboard(&mut self.topemote, broadcast_reciever.resubscribe()),
             calc_leaderboard(
                 &mut self.discordlivestreamchat,
                 broadcast_reciever.resubscribe()

--- a/rust/elo/src/leaderboards/topemote.rs
+++ b/rust/elo/src/leaderboards/topemote.rs
@@ -1,5 +1,5 @@
 /*
-The non-VIPs leaderboard
+Top Emotes leaderboard
 */
 
 use crate::_types::clptypes::{MessageTag, UserChatPerformance};
@@ -8,12 +8,14 @@ use crate::is_message_origin;
 use crate::leaderboards::leaderboardtrait::AbstractLeaderboard;
 use std::collections::HashMap;
 
+const K: f32 = 1.0;
+
 #[derive(Default, Debug)]
-pub struct NonVIPS {
+pub struct TopEmote {
     state: HashMap<String, LeaderboardInnerState>,
 }
 
-impl AbstractLeaderboard for NonVIPS {
+impl AbstractLeaderboard for TopEmote {
     fn new() -> Self {
         let mut out = Self {
             state: HashMap::new(),
@@ -23,7 +25,7 @@ impl AbstractLeaderboard for NonVIPS {
     }
 
     fn get_name(&self) -> String {
-        "nonvips".to_string()
+        "top-emote".to_string()
     }
 
     fn __get_state(&mut self) -> &mut HashMap<String, LeaderboardInnerState> {
@@ -31,15 +33,10 @@ impl AbstractLeaderboard for NonVIPS {
     }
 
     fn calculate_score(&self, performance: &UserChatPerformance) -> Option<f32> {
-        if !(is_message_origin!(performance, MessageTag::Twitch)) {
-            return None;
+        if is_message_origin!(performance, MessageTag::TwitchEmote) {
+            Some(*performance.metrics.get("emote_use").unwrap_or(&0.0) * K)
+        } else {
+            None
         }
-
-        if let Some(special_role) = performance.metadata.get("special_role") {
-            if *special_role.get_bool().unwrap_or(&false) {
-                return None;
-            }
-        }
-        Some(performance.metrics.values().sum())
     }
 }

--- a/rust/elo/src/leaderboards/topemote.rs
+++ b/rust/elo/src/leaderboards/topemote.rs
@@ -33,7 +33,7 @@ impl AbstractLeaderboard for TopEmote {
     }
 
     fn calculate_score(&self, performance: &UserChatPerformance) -> Option<f32> {
-        if is_message_origin!(performance, MessageTag::TwitchEmote) {
+        if is_message_origin!(performance, MessageTag::Emote) {
             Some(*performance.metrics.get("emote_use").unwrap_or(&0.0) * K)
         } else {
             None

--- a/rust/elo/src/lib.rs
+++ b/rust/elo/src/lib.rs
@@ -8,7 +8,7 @@ use log::{debug, warn};
 use metadata::setup_metadata_and_channels;
 use metrics::setup_metrics_and_channels;
 use tokio::sync::mpsc;
-use twitch_utils::seventvclient::SevenTVClient;
+use twitch_utils::{seventvclient::SevenTVClient, TwitchAPIWrapper};
 
 pub mod _constants;
 pub mod _types;
@@ -26,15 +26,12 @@ pub struct MessageProcessor {
 }
 
 impl MessageProcessor {
-    pub async fn new(
-        twitch: &twitch_utils::TwitchAPIWrapper,
-        seventv_client: Arc<SevenTVClient>,
-    ) -> Self {
+    pub async fn new(twitch: &TwitchAPIWrapper, seventv_client: Arc<SevenTVClient>) -> Self {
         let (mut metric_processor, metric_sender, metric_receiver) =
-            setup_metrics_and_channels(seventv_client).await;
+            setup_metrics_and_channels(seventv_client.clone()).await;
 
         let (mut metadata_processor, metadata_sender, metadata_receiver) =
-            setup_metadata_and_channels(twitch).await;
+            setup_metadata_and_channels(twitch, seventv_client).await;
 
         let performances = user_chat_performance_processor(
             metric_processor.defaults.clone(),

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -48,18 +48,18 @@ impl BasicInfo {
             metadata_name: self.get_name(),
             updates: self.seventv_client
                 .get_emotes_in_comment(&comment)
-                .iter()
+                .into_iter()
                 .map(|emote| {
                     (
-                        emote.id.clone(),
-                        MetadataTypes::BasicInfo(emote.name.clone(), emote.url.clone()),
+                        emote.id,
+                        MetadataTypes::BasicInfo(emote.name, emote.url),
                     )
                 })
                 .chain(std::iter::once((
-                    comment.commenter._id.clone(),
+                    comment.commenter._id,
                     MetadataTypes::BasicInfo(
-                        comment.commenter.display_name.clone(),
-                        comment.commenter.logo.clone(),
+                        comment.commenter.display_name,
+                        comment.commenter.logo,
                     ),
                 )))
                 .collect(),

--- a/rust/elo/src/metadata/basic_info.rs
+++ b/rust/elo/src/metadata/basic_info.rs
@@ -1,12 +1,16 @@
 //! Get the username and avatar of the user
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::_types::clptypes::{Message, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
+use twitch_utils::seventvclient::SevenTVClient;
 
 /// Figures out if the user is a special role
-#[derive(Default, Debug)]
-pub struct BasicInfo;
+#[derive(Default)]
+pub struct BasicInfo {
+    seventv_client: Arc<SevenTVClient>,
+}
 
 impl AbstractMetadata for BasicInfo {
     fn get_name(&self) -> String {
@@ -19,16 +23,7 @@ impl AbstractMetadata for BasicInfo {
 
     fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
         match message {
-            Message::Twitch(comment) => MetadataUpdate {
-                metadata_name: self.get_name(),
-                updates: HashMap::from([(
-                    comment.commenter._id.clone(),
-                    MetadataTypes::BasicInfo(
-                        comment.commenter.display_name.clone(),
-                        comment.commenter.logo.clone(),
-                    ),
-                )]),
-            },
+            Message::Twitch(comment) => self.process_twitch(comment),
             Message::Discord(msg) => MetadataUpdate {
                 metadata_name: self.get_name(),
                 updates: HashMap::from([(
@@ -42,7 +37,32 @@ impl AbstractMetadata for BasicInfo {
 }
 
 impl BasicInfo {
-    pub fn new() -> Self {
-        Self
+    pub fn new(seventv_client: Arc<SevenTVClient>) -> Self {
+        Self {
+            seventv_client,
+        }
+    }
+
+    fn process_twitch(&self, comment: twitch_utils::twitchtypes::Comment) -> MetadataUpdate {
+        MetadataUpdate {
+            metadata_name: self.get_name(),
+            updates: self.seventv_client
+                .get_emotes_in_comment(&comment)
+                .iter()
+                .map(|emote| {
+                    (
+                        emote.id.clone(),
+                        MetadataTypes::BasicInfo(emote.name.clone(), emote.url.clone()),
+                    )
+                })
+                .chain(std::iter::once((
+                    comment.commenter._id.clone(),
+                    MetadataTypes::BasicInfo(
+                        comment.commenter.display_name.clone(),
+                        comment.commenter.logo.clone(),
+                    ),
+                )))
+                .collect(),
+        }
     }
 }

--- a/rust/elo/src/metadata/chat_origin.rs
+++ b/rust/elo/src/metadata/chat_origin.rs
@@ -50,11 +50,11 @@ impl ChatOrigin {
     ) -> HashMap<String, MetadataTypes> {
         self.seventv_client
             .get_emotes_in_comment(comment)
-            .iter()
+            .into_iter()
             .map(|emote| {
                 (
                     emote.id.clone(),
-                    MetadataTypes::ChatOrigin(MessageTag::from(emote)),
+                    MetadataTypes::ChatOrigin(MessageTag::from(&Message::from(emote))),
                 )
             })
             .chain(std::iter::once((

--- a/rust/elo/src/metadata/chat_origin.rs
+++ b/rust/elo/src/metadata/chat_origin.rs
@@ -1,12 +1,16 @@
 //! Tags the update with a chat origin
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::_types::clptypes::{Message, MessageTag, MetadataTypes, MetadataUpdate};
 use crate::metadata::metadatatrait::AbstractMetadata;
+use twitch_utils::seventvclient::SevenTVClient;
+use twitch_utils::twitchtypes::Comment;
 
 /// Figures out the association of a message to a chat origin
-#[derive(Default, Debug)]
-pub struct ChatOrigin;
+pub struct ChatOrigin {
+    seventv_client: Arc<SevenTVClient>,
+}
 
 impl AbstractMetadata for ChatOrigin {
     fn get_name(&self) -> String {
@@ -20,21 +24,43 @@ impl AbstractMetadata for ChatOrigin {
     fn get_metadata(&self, message: Message, _sequence_no: u32) -> MetadataUpdate {
         MetadataUpdate {
             metadata_name: self.get_name(),
-            updates: HashMap::from([(
-                match &message {
-                    Message::Discord(msg) => &msg.author.id,
-                    Message::Twitch(comment) => &comment.commenter._id,
-                    _ => return MetadataUpdate::default(),
-                }
-                .to_string(),
-                MetadataTypes::ChatOrigin(MessageTag::from(&message)),
-            )]),
+            updates: match &message {
+                Message::Twitch(comment) => self.process_twitch(comment, &message),
+                Message::Discord(msg) => HashMap::from([(
+                    msg.author.id.to_string(),
+                    MetadataTypes::ChatOrigin(MessageTag::from(&message)),
+                )]),
+                _ => HashMap::new(),
+            },
         }
     }
 }
 
 impl ChatOrigin {
-    pub fn new() -> Self {
-        Self
+    pub fn new(seventv_client: Arc<SevenTVClient>) -> Self {
+        Self {
+            seventv_client,
+        }
+    }
+
+    pub fn process_twitch(
+        &self,
+        comment: &Comment,
+        message: &Message,
+    ) -> HashMap<String, MetadataTypes> {
+        self.seventv_client
+            .get_emotes_in_comment(comment)
+            .iter()
+            .map(|emote| {
+                (
+                    emote.id.clone(),
+                    MetadataTypes::ChatOrigin(MessageTag::from(emote)),
+                )
+            })
+            .chain(std::iter::once((
+                comment.commenter._id.clone(),
+                MetadataTypes::ChatOrigin(MessageTag::from(message)),
+            )))
+            .collect()
     }
 }

--- a/rust/elo/src/metrics/emoteuse.rs
+++ b/rust/elo/src/metrics/emoteuse.rs
@@ -32,16 +32,15 @@ impl AbstractMetric for EmoteUse {
     fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
         let update = match message {
             Message::Twitch(comment) => {
-                let mut updates: HashMap<String, f32> = HashMap::new();
-                self.seventv_client
-                    .get_emotes_in_comment(&comment)
-                    .iter()
-                    .for_each(|emote| {
-                        *updates.entry(emote.id.clone()).or_insert(0.0) += WEIGHT_EMOTES;
-                    });
                 MetricUpdate {
                     metric_name: self.get_name(),
-                    updates,
+                    updates: self.seventv_client
+                        .get_emotes_in_comment(&comment)
+                        .iter()
+                        .fold(HashMap::new(), |mut acc, emote| {
+                            *acc.entry(emote.id.clone()).or_insert(0.0) += WEIGHT_EMOTES;
+                            acc
+                        })
                 }
             }
             _ => MetricUpdate::empty_with_name(self.get_name()), // TODO: discord emotes

--- a/rust/elo/src/metrics/emoteuse.rs
+++ b/rust/elo/src/metrics/emoteuse.rs
@@ -1,0 +1,51 @@
+//! The emote metric
+use std::{collections::HashMap, sync::Arc};
+
+use crate::_types::clptypes::{Message, MetricUpdate};
+use twitch_utils::seventvclient::SevenTVClient;
+
+use super::metrictrait::AbstractMetric;
+
+const WEIGHT_EMOTES: f32 = 1.0;
+
+pub struct EmoteUse {
+    seventv_client: Arc<SevenTVClient>,
+}
+
+impl EmoteUse {
+    pub fn new(seventv_client: Arc<SevenTVClient>) -> Self {
+        Self {
+            seventv_client,
+        }
+    }
+}
+
+impl AbstractMetric for EmoteUse {
+    fn can_parallelize(&self) -> bool {
+        false
+    }
+
+    fn get_name(&self) -> String {
+        String::from("emote_use")
+    }
+
+    fn get_metric(&mut self, message: Message, _sequence_no: u32) -> MetricUpdate {
+        let update = match message {
+            Message::Twitch(comment) => {
+                let mut updates: HashMap<String, f32> = HashMap::new();
+                self.seventv_client
+                    .get_emotes_in_comment(&comment)
+                    .iter()
+                    .for_each(|emote| {
+                        *updates.entry(emote.id.clone()).or_insert(0.0) += WEIGHT_EMOTES;
+                    });
+                MetricUpdate {
+                    metric_name: self.get_name(),
+                    updates,
+                }
+            }
+            _ => MetricUpdate::empty_with_name(self.get_name()), // TODO: discord emotes
+        };
+        update
+    }
+}

--- a/rust/elo/src/metrics/mod.rs
+++ b/rust/elo/src/metrics/mod.rs
@@ -1,6 +1,7 @@
 pub mod bits;
 pub mod copypastaleader;
 pub mod emote;
+pub mod emoteuse;
 pub mod metrictrait;
 pub mod subs;
 pub mod text;
@@ -27,6 +28,7 @@ pub struct MetricProcessor {
     text: text::Text,
     copypastaleader: copypastaleader::CopypastaLeader,
     emote: emote::Emote,
+    emote_use: emoteuse::EmoteUse,
 }
 
 impl MetricProcessor {
@@ -43,13 +45,15 @@ impl MetricProcessor {
         let subs = subs::Subs::new();
         let text = text::Text::new();
         let copypastaleader = copypastaleader::CopypastaLeader::new();
-        let emote = emote::Emote::new(seventv_client);
+        let emote = emote::Emote::new(seventv_client.clone());
+        let emote_use = emoteuse::EmoteUse::new(seventv_client);
 
         defaults.insert(bits.get_name(), 0.0);
         defaults.insert(subs.get_name(), 0.0);
         defaults.insert(text.get_name(), 0.0);
         defaults.insert(copypastaleader.get_name(), 0.0);
         defaults.insert(emote.get_name(), 0.0);
+        defaults.insert(emote_use.get_name(), 0.0);
 
         Self {
             defaults,
@@ -60,6 +64,7 @@ impl MetricProcessor {
             text,
             copypastaleader,
             emote,
+            emote_use,
         }
     }
 
@@ -87,6 +92,11 @@ impl MetricProcessor {
             ),
             calc_metric(
                 &mut self.emote,
+                self.mpsc_sender.clone(),
+                self.broadcast_receiver.resubscribe(),
+            ),
+            calc_metric(
+                &mut self.emote_use,
                 self.mpsc_sender.clone(),
                 self.broadcast_receiver.resubscribe(),
             ),

--- a/rust/twitch_utils/src/twitchtypes.rs
+++ b/rust/twitch_utils/src/twitchtypes.rs
@@ -65,10 +65,21 @@ impl From<ChannelEmote> for TwitchEmote {
 
 impl From<RawSevenTVEmote> for SevenTVEmote {
     fn from(raw_emote: RawSevenTVEmote) -> Self {
-        Self {
-            id: raw_emote.id,
-            name: raw_emote.name,
-            emote_url: raw_emote.host.url,
+        let largest_width_file = raw_emote.host.files.iter().max_by_key(|file| file.width);
+        if let Some(file) = largest_width_file {
+            let url = raw_emote.host.url + "/" + &file.name;
+            Self {
+                id: raw_emote.id,
+                name: raw_emote.name,
+                emote_url: url,
+            }
+        } else {
+            // Use technical difficulties emote if no files are found
+            Self {
+                id: raw_emote.id,
+                name: raw_emote.name,
+                emote_url: String::from("https://cdn.7tv.app/emote/63384017cf7eb48c4e731a79/4x.webp"),
+            }
         }
     }
 }

--- a/web/src/lib/menu.svelte
+++ b/web/src/lib/menu.svelte
@@ -9,7 +9,8 @@
     Copypasta: 3,
     Bits: 4,
     Subs: 5,
-    'Partner Only': 6
+    'Partner Only': 6,
+    'Top Emotes': 8
   };
   const discordMenuItemMapping = {
     '#livestream-chat': 7

--- a/web/src/lib/menu.svelte
+++ b/web/src/lib/menu.svelte
@@ -10,7 +10,7 @@
     Bits: 4,
     Subs: 5,
     'Partner Only': 6,
-    'Top Emotes': 8
+    'Top Emotes': 9
   };
   const discordMenuItemMapping = {
     '#livestream-chat': 7

--- a/web/src/lib/ranks.ts
+++ b/web/src/lib/ranks.ts
@@ -75,3 +75,4 @@ export const bitsRank = readable([], makeRankingInfo('bits-only.bin'));
 export const subsRank = readable([], makeRankingInfo('subs-only.bin'));
 export const discordRank = readable([], makeRankingInfo('discordlivestream.bin'))
 export const partnersRank = readable([], makeRankingInfo('partners-only.bin'))
+export const emoteRank = readable([], makeRankingInfo('top-emote.bin'));

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -10,8 +10,8 @@
     nonvipsRank,
     bitsRank,
     subsRank,
-    partnersRank,
     discordRank,
+    partnersRank,
     emoteRank
   } from '$lib/ranks';
   import { sanitizeString } from '$lib';

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -41,8 +41,8 @@
     $copypastaRank,
     $bitsRank,
     $subsRank,
-    $discordRank,
     $partnersRank,
+    $discordRank,
     $emoteRank
   ];
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -10,8 +10,9 @@
     nonvipsRank,
     bitsRank,
     subsRank,
+    partnersRank,
     discordRank,
-    partnersRank
+    emoteRank
   } from '$lib/ranks';
   import { sanitizeString } from '$lib';
   import Menu from '$lib/menu.svelte';
@@ -30,7 +31,8 @@
     'Bits',
     'Subs',
     'Partners',
-    '#livestream-chat'
+    '#livestream-chat',
+    'Top Emotes'
   ];
   $: ranking = [
     $overallRank,
@@ -39,8 +41,9 @@
     $copypastaRank,
     $bitsRank,
     $subsRank,
+    $discordRank,
     $partnersRank,
-    $discordRank
+    $emoteRank
   ];
 
   $: allRanksLoaded = ranking.every((r) => r.length > 0);

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -32,6 +32,7 @@
     'Subs',
     'Partners',
     '#livestream-chat',
+    '',
     'Top Emotes'
   ];
   $: ranking = [
@@ -43,6 +44,7 @@
     $subsRank,
     $partnersRank,
     $discordRank,
+    $discordRank, // Temp filler
     $emoteRank
   ];
 


### PR DESCRIPTION
# Changes

This PR contains three units of change. 
- Creation of a new `MessageTag` called `Emote` and integration with the `ChatOrigin` metadata
- Extraction of emote `BasicInfo` in `basic_info.rs`
- The `top-emote` leaderboard with its associated `emote-use` metric

`ChatOrigin` will now output a `MetadataUpdate` that contains both the `MessageTag` for the `userId`, as well as for all of the emotes in their Message. The Emote `MessageTag` is constructed by passing the emote to `MessageTage::from`, with plans to eventually support discord emotes.

The `BasicInfo` metadata processor now produces `BasicInfo` metadata types for both the user, and all emotes in their Message.

The `top-emote` leaderboard tracks emote use with the `emote-use` metric. The metric adds one score to an emote whenever it appears in a message.

## Checklist

- [x] My code compiles
- [x] I have committed all the files needed to build the project (check if your file is found in `.gitignore`)
- [x] If I'm introducing a new step in the build process, I have documented / automated it
- [x] I have tested my changes (minimally with one Twitch VOD)

## Related Cards

- https://github.com/orgs/vanorsigma/projects/1?pane=issue&itemId=76010173
