### PR TITLE
Backfill gets last 5 VOD ids

### DIFF
--- a/rust/chatdownloader/src/backfill.rs
+++ b/rust/chatdownloader/src/backfill.rs
@@ -15,7 +15,7 @@ pub async fn backfill() {
     let twitch = TwitchAPIWrapper::new().await.unwrap();
     let seventv_client = Arc::new(SevenTVClient::new().await);
     let video_ids = twitch
-        .get_latest_vods(elo::_constants::VED_CH_ID.to_string(), 5)
+        .get_latest_vod_ids(elo::_constants::VED_CH_ID.to_string(), 5)
         .await;
     let mut downloader = TwitchChatDownloader::new();
 

--- a/rust/chatdownloader/src/backfill.rs
+++ b/rust/chatdownloader/src/backfill.rs
@@ -11,27 +11,15 @@ use crate::chatlogprocessor::ChatLogProcessor;
 use crate::twitchdownloaderproxy::TwitchChatDownloader;
 use twitch_utils::TwitchAPIWrapper;
 
-const VIDEO_IDS: [&str; 12] = [
-    "2170316549",
-    "2171991671",
-    "2172878349",
-    "2176205867",
-    "2175349344",
-    "2178862405",
-    "2188296968",
-    "2187465183",
-    "2182332760",
-    "2181468979",
-    "2180615386",
-    "2179780834",
-];
-
 pub async fn backfill() {
     let twitch = TwitchAPIWrapper::new().await.unwrap();
     let seventv_client = Arc::new(SevenTVClient::new().await);
+    let video_ids = twitch
+        .get_latest_vods(elo::_constants::VED_CH_ID.to_string(), 5)
+        .await;
     let mut downloader = TwitchChatDownloader::new();
 
-    for video_id in VIDEO_IDS.iter() {
+    for video_id in video_ids.iter() {
         info!("Backfilling for video ID: {}", video_id);
         // let chat_log = downloader.download_chat(video_id).await.unwrap();
         let chat_log = downloader

--- a/rust/chatdownloader/src/main.rs
+++ b/rust/chatdownloader/src/main.rs
@@ -31,8 +31,9 @@ async fn main() {
 
     let twitch = TwitchAPIWrapper::new().await.unwrap();
     let vod_id = twitch
-        .get_latest_vod_id(elo::_constants::VED_CH_ID.to_string())
-        .await;
+        .get_latest_vods(elo::_constants::VED_CH_ID.to_string(), 1)
+        .await[0]
+        .clone();
 
     info!("Script triggered, pulling logs for VOD ID: {}...", vod_id);
 

--- a/rust/chatdownloader/src/main.rs
+++ b/rust/chatdownloader/src/main.rs
@@ -31,7 +31,7 @@ async fn main() {
 
     let twitch = TwitchAPIWrapper::new().await.unwrap();
     let vod_id = twitch
-        .get_latest_vods(elo::_constants::VED_CH_ID.to_string(), 1)
+        .get_latest_vod_ids(elo::_constants::VED_CH_ID.to_string(), 1)
         .await[0]
         .clone();
 

--- a/rust/twitch_utils/src/lib.rs
+++ b/rust/twitch_utils/src/lib.rs
@@ -73,10 +73,17 @@ impl TwitchAPIWrapper {
         Ok(Self { twitch, token })
     }
 
-    pub async fn get_latest_vod_id(&self, ch_id: String) -> String {
+    pub async fn get_latest_vods(&self, ch_id: String, num: usize) -> Vec<String> {
         let request = GetVideosRequest::user_id(ch_id.clone());
         let response = self.twitch.req_get(request, &self.token);
-        response.await.unwrap().data[0].id.clone().to_string()
+        response
+            .await
+            .unwrap()
+            .data
+            .iter()
+            .take(num)
+            .map(|v| v.id.clone().to_string())
+            .collect()
     }
 
     /// Returns a tuple (start timestamp and end timestamp) of the VOD

--- a/rust/twitch_utils/src/lib.rs
+++ b/rust/twitch_utils/src/lib.rs
@@ -83,6 +83,7 @@ impl TwitchAPIWrapper {
             .iter()
             .take(num)
             .map(|v| v.id.clone().to_string())
+            .rev()
             .collect()
     }
 

--- a/rust/twitch_utils/src/lib.rs
+++ b/rust/twitch_utils/src/lib.rs
@@ -73,7 +73,7 @@ impl TwitchAPIWrapper {
         Ok(Self { twitch, token })
     }
 
-    pub async fn get_latest_vods(&self, ch_id: String, num: usize) -> Vec<String> {
+    pub async fn get_latest_vod_ids(&self, ch_id: String, num: usize) -> Vec<String> {
         let request = GetVideosRequest::user_id(ch_id.clone());
         let response = self.twitch.req_get(request, &self.token);
         response


### PR DESCRIPTION
# Changes

This PR replaces `get_latest_vod_id` with `get_latest_vod_ids`. This function takes the channel ID as before, but also the number of VODs to get IDs for., returning a list of VOD ids. The VOD id list is reversed to ensure that VODs are processed in the correct order (oldest -> newest).

The Backfill funciton now calls this function to get the last 5 VOD ids and backfills from them.

Main will now call this function with 1 to get just the latest VOD.

## Checklist

- [x] My code compiles
- [x] I have committed all the files needed to build the project (check if your file is found in `.gitignore`)
- [x] If I'm introducing a new step in the build process, I have documented / automated it
- [x] I have tested my changes (minimally with one Twitch VOD)

## Related Cards

- https://github.com/orgs/vanorsigma/projects/1?pane=issue&itemId=75139611