### PR TITLE
Resolve metric & metadata broadcast race condition

### DIFF
--- a/rust/chatdownloader/src/chatlogprocessor.rs
+++ b/rust/chatdownloader/src/chatlogprocessor.rs
@@ -1,4 +1,4 @@
-use elo::MessageProcessor;
+use elo::{MessageProcessorSetup, MessageProcessorRunning};
 use elo::_types::clptypes::{Message, UserChatPerformance};
 use elo::leaderboards::LeaderboardProcessor;
 use log::{debug, info};
@@ -19,12 +19,15 @@ pub struct ChatLogProcessor {
     and the leaderboards package to export the metrics / required user
     metadata to the right people
     */
-    message_processor: MessageProcessor,
+    message_processor: MessageProcessorRunning,
 }
 
 impl ChatLogProcessor {
     pub async fn new(twitch: &TwitchAPIWrapper, seventv_client: Arc<SevenTVClient>) -> Self {
-        let message_processor = MessageProcessor::new(twitch, seventv_client).await;
+        let message_processor = MessageProcessorSetup::new(twitch, seventv_client)
+            .await
+            .start()
+            .await;
 
         Self { message_processor }
     }

--- a/rust/elo/Cargo.toml
+++ b/rust/elo/Cargo.toml
@@ -11,7 +11,7 @@ prost-build = "0.13.1"
 serde = {version = "1.0.203", features = ["derive"]}
 serde_json = "1.0.117"
 log = "0.4.21"
-tokio = {version = "1.38.0", features = ["full"]}
+tokio = {version = "1.40.0", features = ["full"]}
 futures = "0.3.30"
 lazy_static = "1.5.0"
 twitch_api = { version = "0.7.0-rc.7", features = ["all", "reqwest"] }

--- a/rust/elo/src/lib.rs
+++ b/rust/elo/src/lib.rs
@@ -18,7 +18,7 @@ pub mod leaderboards;
 pub mod metadata;
 pub mod metrics;
 
-/// Struct to setup the spawn metric and metadata processors
+/// Struct to setup a MessageProcessorRunning and spawn metric/metadata processors
 /// 
 /// Call .start() to spawn tasks and get a `MessageProcessorRunning` struct
 pub struct MessageProcessorSetup {
@@ -62,7 +62,6 @@ impl MessageProcessorSetup {
             performance_sender,
         );
 
-        debug!("Starting message processors");
         let mut joins = JoinSet::new();
         joins.spawn(async move { self.metric_processor.run().await });
         joins.spawn(async move { self.metadata_processor.run().await });
@@ -80,8 +79,6 @@ impl MessageProcessorSetup {
 }
 
 /// A running message processor that can process messages
-/// 
-/// This struct should not be constructed on its own, it is created by calling `start` on a `MessageProcessorSetup`
 pub struct MessageProcessorRunning {
     joins: JoinSet<()>,
     metric_sender: tokio::sync::broadcast::Sender<(Message, u32)>,

--- a/rust/elo/src/metadata/mod.rs
+++ b/rust/elo/src/metadata/mod.rs
@@ -19,14 +19,44 @@ use crate::_types::clptypes::MetadataUpdate;
 use crate::metadata::metadatatrait::AbstractMetadata;
 use twitch_utils::TwitchAPIWrapper;
 
+struct WithReceiver<M: AbstractMetadata> {
+    pub metadata: M,
+    pub receiver: broadcast::Receiver<(Message, u32)>,
+    pub sender: mpsc::Sender<MetadataUpdate>,
+}
+
+impl<M: AbstractMetadata> WithReceiver<M> {
+    fn new(
+        metadata: M,
+        receiver: &broadcast::Receiver<(Message, u32)>,
+        sender: &mpsc::Sender<MetadataUpdate>,
+    ) -> Self {
+        Self {
+            metadata,
+            receiver: receiver.resubscribe(),
+            sender: sender.clone(),
+        }
+    }
+
+    fn get_name(&self) -> String {
+        self.metadata.get_name()
+    }
+
+    fn get_metadata(&mut self, message: Message, sequence_no: u32) -> MetadataUpdate {
+        self.metadata.get_metadata(message, sequence_no)
+    }
+
+    fn get_default_value(&self) -> MetadataTypes {
+        self.metadata.get_default_value()
+    }
+}
+
 pub struct MetadataProcessor {
     pub defaults: HashMap<String, MetadataTypes>,
-    broadcast_receiver: broadcast::Receiver<(Message, u32)>,
-    mpsc_sender: mpsc::Sender<MetadataUpdate>,
-    basic_info: basic_info::BasicInfo,
-    badges: badges::Badges,
-    special_role: special_role::SpecialRole,
-    chat_origin: chat_origin::ChatOrigin,
+    basic_info: WithReceiver<basic_info::BasicInfo>,
+    badges: WithReceiver<badges::Badges>,
+    special_role: WithReceiver<special_role::SpecialRole>,
+    chat_origin: WithReceiver<chat_origin::ChatOrigin>,
 }
 
 impl MetadataProcessor {
@@ -39,10 +69,10 @@ impl MetadataProcessor {
         let mut defaults: HashMap<String, MetadataTypes> = HashMap::new();
 
         // Initialize the metadata
-        let basic_info = basic_info::BasicInfo::new(seventv_client.clone());
-        let badges = badges::Badges::new(twitch).await;
-        let special_role = special_role::SpecialRole::new();
-        let chat_origin = chat_origin::ChatOrigin::new(seventv_client);
+        let basic_info = WithReceiver::new(basic_info::BasicInfo::new(seventv_client.clone()), &broadcast_receiver, &mpsc_sender);
+        let badges = WithReceiver::new(badges::Badges::new(twitch).await, &broadcast_receiver, &mpsc_sender);
+        let special_role = WithReceiver::new(special_role::SpecialRole::new(), &broadcast_receiver, &mpsc_sender);
+        let chat_origin = WithReceiver::new(chat_origin::ChatOrigin::new(seventv_client), &broadcast_receiver, &mpsc_sender);
 
         // Add names and default values to the metadata
         defaults.insert(basic_info.get_name(), basic_info.get_default_value());
@@ -52,8 +82,6 @@ impl MetadataProcessor {
 
         Self {
             defaults,
-            broadcast_receiver,
-            mpsc_sender,
             basic_info,
             badges,
             special_role,
@@ -63,42 +91,24 @@ impl MetadataProcessor {
 
     pub async fn run(&mut self) {
         join!(
-            calc_metadata(
-                &mut self.basic_info,
-                self.mpsc_sender.clone(),
-                self.broadcast_receiver.resubscribe(),
-            ),
-            calc_metadata(
-                &mut self.badges,
-                self.mpsc_sender.clone(),
-                self.broadcast_receiver.resubscribe(),
-            ),
-            calc_metadata(
-                &mut self.special_role,
-                self.mpsc_sender.clone(),
-                self.broadcast_receiver.resubscribe(),
-            ),
-            calc_metadata(
-                &mut self.chat_origin,
-                self.mpsc_sender.clone(),
-                self.broadcast_receiver.resubscribe(),
-            ),
+            calc_metadata(&mut self.basic_info),
+            calc_metadata(&mut self.badges),
+            calc_metadata(&mut self.special_role),
+            calc_metadata(&mut self.chat_origin),
         );
         debug!("All metadata finished");
     }
 }
 
 async fn calc_metadata<M: AbstractMetadata + Send + Sync + 'static>(
-    metadata: &mut M,
-    sender: mpsc::Sender<MetadataUpdate>,
-    mut reciever: broadcast::Receiver<(Message, u32)>,
+    metadata: &mut WithReceiver<M>,
 ) {
     /*
     Find metadata based on chat messages sent by a tokio broadcast channel
     */
-    while let Ok((message, sequence_no)) = reciever.recv().await {
-        let metadata = (*metadata).get_metadata(message, sequence_no);
-        if let Err(e) = sender.send(metadata).await {
+    while let Ok((message, sequence_no)) = metadata.receiver.recv().await {
+        let metadata_update = (*metadata).get_metadata(message, sequence_no);
+        if let Err(e) = metadata.sender.send(metadata_update).await {
             warn!("Failed to send metadata result {}", e)
         };
     }


### PR DESCRIPTION
# Changes

This PR has two main units of change, aiming to close #32 (read for background): 
- Splitting MessageProcessor into `Setup` and `Running` variants to ensure no tasks are spawned in new()
- Wrap Metrics and Metadata with a decorator containing a cloned sender and resubscribed receiver in MetricProcessor.new(), and MetadataProcessor.new() respectively. This provides a guarantee that all receivers are subscribed as soon as the constructor returns.

`MetricProcessorSetup` creates the Metric and Metadata processors / channels. Calling `.start()` will consume the `MetricProcessorSetup`, starting processor threads and producing a `MetricProcessorRunning`. `MetricProcessorRunning` is a drop in replacement for the original `MetricProcessor`.

Metric and Metadata now have a `WithReceiver` decorator, which contains a subscribed receiver and sender. These decorators are constructed sync in the Metric and Metadata constructors, ensuring that all receivers are subscribed before the processing continues.

## Checklist

- [x] My code compiles
- [x] I have committed all the files needed to build the project (check if your file is found in `.gitignore`)
- [x] If I'm introducing a new step in the build process, I have documented / automated it
- [x] I have tested my changes (minimally with one Twitch VOD)
